### PR TITLE
Share formatting context across formatters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,7 +126,7 @@ dependencies = [
 [[package]]
 name = "biome_aria"
 version = "0.5.7"
-source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#66bf8a40e8a7daa94ba1c8038e691191c65b5506"
+source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#8436c26b72ffe6ec1c3ee6241e70ed8cd93b37e8"
 dependencies = [
  "biome_aria_metadata",
 ]
@@ -134,7 +134,7 @@ dependencies = [
 [[package]]
 name = "biome_aria_metadata"
 version = "0.5.7"
-source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#66bf8a40e8a7daa94ba1c8038e691191c65b5506"
+source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#8436c26b72ffe6ec1c3ee6241e70ed8cd93b37e8"
 dependencies = [
  "biome_deserialize",
  "biome_deserialize_macros",
@@ -150,7 +150,7 @@ dependencies = [
 [[package]]
 name = "biome_console"
 version = "0.5.7"
-source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#66bf8a40e8a7daa94ba1c8038e691191c65b5506"
+source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#8436c26b72ffe6ec1c3ee6241e70ed8cd93b37e8"
 dependencies = [
  "biome_markup",
  "biome_text_size",
@@ -163,7 +163,7 @@ dependencies = [
 [[package]]
 name = "biome_css_factory"
 version = "0.5.7"
-source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#66bf8a40e8a7daa94ba1c8038e691191c65b5506"
+source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#8436c26b72ffe6ec1c3ee6241e70ed8cd93b37e8"
 dependencies = [
  "biome_css_syntax",
  "biome_rowan",
@@ -172,7 +172,7 @@ dependencies = [
 [[package]]
 name = "biome_css_formatter"
 version = "0.5.7"
-source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#66bf8a40e8a7daa94ba1c8038e691191c65b5506"
+source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#8436c26b72ffe6ec1c3ee6241e70ed8cd93b37e8"
 dependencies = [
  "biome_css_syntax",
  "biome_diagnostics",
@@ -185,7 +185,7 @@ dependencies = [
 [[package]]
 name = "biome_css_parser"
 version = "0.5.7"
-source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#66bf8a40e8a7daa94ba1c8038e691191c65b5506"
+source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#8436c26b72ffe6ec1c3ee6241e70ed8cd93b37e8"
 dependencies = [
  "biome_console",
  "biome_css_factory",
@@ -200,7 +200,7 @@ dependencies = [
 [[package]]
 name = "biome_css_syntax"
 version = "0.5.7"
-source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#66bf8a40e8a7daa94ba1c8038e691191c65b5506"
+source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#8436c26b72ffe6ec1c3ee6241e70ed8cd93b37e8"
 dependencies = [
  "biome_rowan",
  "biome_string_case",
@@ -211,7 +211,7 @@ dependencies = [
 [[package]]
 name = "biome_deserialize"
 version = "0.6.0"
-source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#66bf8a40e8a7daa94ba1c8038e691191c65b5506"
+source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#8436c26b72ffe6ec1c3ee6241e70ed8cd93b37e8"
 dependencies = [
  "biome_console",
  "biome_diagnostics",
@@ -224,10 +224,10 @@ dependencies = [
 [[package]]
 name = "biome_deserialize_macros"
 version = "0.6.0"
-source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#66bf8a40e8a7daa94ba1c8038e691191c65b5506"
+source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#8436c26b72ffe6ec1c3ee6241e70ed8cd93b37e8"
 dependencies = [
  "biome_string_case",
- "proc-macro-error",
+ "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -236,7 +236,7 @@ dependencies = [
 [[package]]
 name = "biome_diagnostics"
 version = "0.5.7"
-source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#66bf8a40e8a7daa94ba1c8038e691191c65b5506"
+source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#8436c26b72ffe6ec1c3ee6241e70ed8cd93b37e8"
 dependencies = [
  "backtrace",
  "biome_console",
@@ -256,7 +256,7 @@ dependencies = [
 [[package]]
 name = "biome_diagnostics_categories"
 version = "0.5.7"
-source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#66bf8a40e8a7daa94ba1c8038e691191c65b5506"
+source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#8436c26b72ffe6ec1c3ee6241e70ed8cd93b37e8"
 dependencies = [
  "quote",
  "serde",
@@ -265,9 +265,9 @@ dependencies = [
 [[package]]
 name = "biome_diagnostics_macros"
 version = "0.5.7"
-source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#66bf8a40e8a7daa94ba1c8038e691191c65b5506"
+source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#8436c26b72ffe6ec1c3ee6241e70ed8cd93b37e8"
 dependencies = [
- "proc-macro-error",
+ "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -276,7 +276,7 @@ dependencies = [
 [[package]]
 name = "biome_formatter"
 version = "0.5.7"
-source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#66bf8a40e8a7daa94ba1c8038e691191c65b5506"
+source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#8436c26b72ffe6ec1c3ee6241e70ed8cd93b37e8"
 dependencies = [
  "biome_console",
  "biome_deserialize",
@@ -297,7 +297,7 @@ dependencies = [
 [[package]]
 name = "biome_html_factory"
 version = "0.5.7"
-source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#66bf8a40e8a7daa94ba1c8038e691191c65b5506"
+source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#8436c26b72ffe6ec1c3ee6241e70ed8cd93b37e8"
 dependencies = [
  "biome_html_syntax",
  "biome_rowan",
@@ -306,7 +306,7 @@ dependencies = [
 [[package]]
 name = "biome_html_formatter"
 version = "0.0.0"
-source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#66bf8a40e8a7daa94ba1c8038e691191c65b5506"
+source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#8436c26b72ffe6ec1c3ee6241e70ed8cd93b37e8"
 dependencies = [
  "biome_deserialize",
  "biome_deserialize_macros",
@@ -314,13 +314,14 @@ dependencies = [
  "biome_formatter",
  "biome_html_syntax",
  "biome_rowan",
+ "biome_string_case",
  "biome_suppression",
 ]
 
 [[package]]
 name = "biome_html_parser"
 version = "0.0.1"
-source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#66bf8a40e8a7daa94ba1c8038e691191c65b5506"
+source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#8436c26b72ffe6ec1c3ee6241e70ed8cd93b37e8"
 dependencies = [
  "biome_console",
  "biome_diagnostics",
@@ -335,7 +336,7 @@ dependencies = [
 [[package]]
 name = "biome_html_syntax"
 version = "0.5.7"
-source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#66bf8a40e8a7daa94ba1c8038e691191c65b5506"
+source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#8436c26b72ffe6ec1c3ee6241e70ed8cd93b37e8"
 dependencies = [
  "biome_rowan",
  "biome_string_case",
@@ -346,7 +347,7 @@ dependencies = [
 [[package]]
 name = "biome_js_factory"
 version = "0.5.7"
-source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#66bf8a40e8a7daa94ba1c8038e691191c65b5506"
+source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#8436c26b72ffe6ec1c3ee6241e70ed8cd93b37e8"
 dependencies = [
  "biome_js_syntax",
  "biome_rowan",
@@ -355,7 +356,7 @@ dependencies = [
 [[package]]
 name = "biome_js_formatter"
 version = "0.5.7"
-source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#66bf8a40e8a7daa94ba1c8038e691191c65b5506"
+source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#8436c26b72ffe6ec1c3ee6241e70ed8cd93b37e8"
 dependencies = [
  "biome_deserialize",
  "biome_deserialize_macros",
@@ -376,7 +377,7 @@ dependencies = [
 [[package]]
 name = "biome_js_parser"
 version = "0.5.7"
-source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#66bf8a40e8a7daa94ba1c8038e691191c65b5506"
+source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#8436c26b72ffe6ec1c3ee6241e70ed8cd93b37e8"
 dependencies = [
  "biome_console",
  "biome_diagnostics",
@@ -397,7 +398,7 @@ dependencies = [
 [[package]]
 name = "biome_js_syntax"
 version = "0.5.7"
-source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#66bf8a40e8a7daa94ba1c8038e691191c65b5506"
+source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#8436c26b72ffe6ec1c3ee6241e70ed8cd93b37e8"
 dependencies = [
  "biome_aria",
  "biome_aria_metadata",
@@ -411,7 +412,7 @@ dependencies = [
 [[package]]
 name = "biome_json_factory"
 version = "0.5.7"
-source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#66bf8a40e8a7daa94ba1c8038e691191c65b5506"
+source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#8436c26b72ffe6ec1c3ee6241e70ed8cd93b37e8"
 dependencies = [
  "biome_json_syntax",
  "biome_rowan",
@@ -420,7 +421,7 @@ dependencies = [
 [[package]]
 name = "biome_json_parser"
 version = "0.5.7"
-source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#66bf8a40e8a7daa94ba1c8038e691191c65b5506"
+source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#8436c26b72ffe6ec1c3ee6241e70ed8cd93b37e8"
 dependencies = [
  "biome_console",
  "biome_diagnostics",
@@ -436,7 +437,7 @@ dependencies = [
 [[package]]
 name = "biome_json_syntax"
 version = "0.5.7"
-source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#66bf8a40e8a7daa94ba1c8038e691191c65b5506"
+source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#8436c26b72ffe6ec1c3ee6241e70ed8cd93b37e8"
 dependencies = [
  "biome_rowan",
  "biome_string_case",
@@ -447,9 +448,9 @@ dependencies = [
 [[package]]
 name = "biome_markup"
 version = "0.5.7"
-source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#66bf8a40e8a7daa94ba1c8038e691191c65b5506"
+source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#8436c26b72ffe6ec1c3ee6241e70ed8cd93b37e8"
 dependencies = [
- "proc-macro-error",
+ "proc-macro-error2",
  "proc-macro2",
  "quote",
 ]
@@ -457,7 +458,7 @@ dependencies = [
 [[package]]
 name = "biome_parser"
 version = "0.5.7"
-source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#66bf8a40e8a7daa94ba1c8038e691191c65b5506"
+source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#8436c26b72ffe6ec1c3ee6241e70ed8cd93b37e8"
 dependencies = [
  "biome_console",
  "biome_diagnostics",
@@ -471,12 +472,12 @@ dependencies = [
 [[package]]
 name = "biome_rowan"
 version = "0.5.7"
-source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#66bf8a40e8a7daa94ba1c8038e691191c65b5506"
+source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#8436c26b72ffe6ec1c3ee6241e70ed8cd93b37e8"
 dependencies = [
  "biome_text_edit",
  "biome_text_size",
  "countme",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
  "rustc-hash",
  "serde",
 ]
@@ -484,23 +485,22 @@ dependencies = [
 [[package]]
 name = "biome_string_case"
 version = "0.5.7"
-source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#66bf8a40e8a7daa94ba1c8038e691191c65b5506"
+source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#8436c26b72ffe6ec1c3ee6241e70ed8cd93b37e8"
 
 [[package]]
 name = "biome_suppression"
 version = "0.5.7"
-source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#66bf8a40e8a7daa94ba1c8038e691191c65b5506"
+source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#8436c26b72ffe6ec1c3ee6241e70ed8cd93b37e8"
 dependencies = [
  "biome_console",
  "biome_diagnostics",
  "biome_rowan",
- "log",
 ]
 
 [[package]]
 name = "biome_text_edit"
 version = "0.5.7"
-source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#66bf8a40e8a7daa94ba1c8038e691191c65b5506"
+source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#8436c26b72ffe6ec1c3ee6241e70ed8cd93b37e8"
 dependencies = [
  "biome_text_size",
  "serde",
@@ -510,7 +510,7 @@ dependencies = [
 [[package]]
 name = "biome_text_size"
 version = "0.5.7"
-source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#66bf8a40e8a7daa94ba1c8038e691191c65b5506"
+source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#8436c26b72ffe6ec1c3ee6241e70ed8cd93b37e8"
 dependencies = [
  "serde",
 ]
@@ -518,7 +518,7 @@ dependencies = [
 [[package]]
 name = "biome_unicode_table"
 version = "0.5.7"
-source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#66bf8a40e8a7daa94ba1c8038e691191c65b5506"
+source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#8436c26b72ffe6ec1c3ee6241e70ed8cd93b37e8"
 
 [[package]]
 name = "bitflags"
@@ -566,6 +566,7 @@ dependencies = [
  "biome_css_formatter",
  "biome_css_parser",
  "biome_diagnostics",
+ "biome_formatter",
  "biome_html_formatter",
  "biome_html_parser",
  "biome_html_syntax",
@@ -652,7 +653,9 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "codespan-reporting",
+ "itertools",
  "log",
+ "num-traits",
  "once_cell",
  "path-absolutize",
  "schemars",
@@ -669,6 +672,7 @@ dependencies = [
  "bl_lints",
  "bl_utils",
  "dashmap",
+ "derive_more",
  "globset",
  "ignore",
  "index_vec",
@@ -702,14 +706,20 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.11.3"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
 dependencies = [
  "memchr",
  "regex-automata",
  "serde",
 ]
+
+[[package]]
+name = "bytecount"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
 
 [[package]]
 name = "camino"
@@ -725,9 +735,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.35"
+version = "4.5.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8aa86934b44c19c50f87cc2790e19f54f7a67aedb64101c2e1a2e5ecfb73944"
+checksum = "2df961d8c8a0d08aa9945718ccf584145eee3f3aa06cddbeac12933781102e04"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -735,9 +745,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.35"
+version = "4.5.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2414dbb2dd0695280da6ea9261e327479e9d37b0630f6b53ba2a11c60c679fd9"
+checksum = "132dbda40fb6753878316a489d5a1242a8ef2f0d9e47ba01c951ea8aa7d013a5"
 dependencies = [
  "anstream",
  "anstyle",
@@ -804,9 +814,9 @@ checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1085,9 +1095,9 @@ checksum = "29fc123b2f6600099ca18248f69e3ee02b09c4188c0d98e9a690d90dec3e408a"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "lock_api"
@@ -1117,9 +1127,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff70ce3e48ae43fa075863cef62e8b43b71a4f2382229920e0df362592919430"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
 ]
@@ -1268,26 +1278,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
+name = "proc-macro-error-attr2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
 dependencies = [
- "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "version_check",
 ]
 
 [[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
+name = "proc-macro-error2"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
 dependencies = [
+ "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "version_check",
 ]
 
 [[package]]
@@ -1754,12 +1762,6 @@ dependencies = [
  "sval_ref",
  "sval_serde",
 ]
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -532,10 +532,12 @@ version = "0.1.0"
 dependencies = [
  "bl_macros",
  "bl_utils",
+ "bytecount",
  "derive_more",
  "index_vec",
  "itertools",
  "line-span",
+ "num-traits",
  "once_cell",
  "parking_lot",
  "replace_with",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ annotate-snippets = { version = "0.11.4" }
 anyhow = { version = "1.0.80" }
 argfile = { version = "0.2.0" }
 bitflags = { version = "2.5.0" }
+bytecount = { version = "0.6.8" }
 clap = { version = "4.5.3", features = ["derive"] }
 colored = { version = "2.1.0" }
 convert_case ="0.4"

--- a/crates/bl/src/commands/fmt.rs
+++ b/crates/bl/src/commands/fmt.rs
@@ -3,7 +3,7 @@
 use std::{fs, io::Write, path::PathBuf};
 
 use anyhow::Result;
-use bl_fmt::{FmtOptions, FmtQuery, FmtQueryResult, fmt_module};
+use bl_fmt::{FormatQuery, FormatQueryResult, FormatterOptions, fmt_module};
 use bl_lints::{diff::Diff, settings};
 use bl_parse::{ParseQuery, ParseQueryResult, parse_source};
 use bl_reporting::Reports;
@@ -70,7 +70,7 @@ pub fn fmt(files: &[PathBuf], workspace: &mut Workspace) -> Result<Reports> {
         },
     );
 
-    let options = FmtOptions::default();
+    let options = FormatterOptions::default();
     let settings = &workspace.settings;
 
     // Now let's try and "format" all of the documents that we got
@@ -78,8 +78,8 @@ pub fn fmt(files: &[PathBuf], workspace: &mut Workspace) -> Result<Reports> {
     //
     // @@Temp: for now we will just print the produced contents.
     for (source, member) in workspace.members.iter() {
-        let FmtQueryResult { buffer, diagnostics } =
-            fmt_module(FmtQuery { member, source, options });
+        let FormatQueryResult { buffer, diagnostics } =
+            fmt_module(FormatQuery { member, source, options });
         pipeline_diagnostics.extend(diagnostics);
 
         // @@Todo: factor this out into a general interface for emitting

--- a/crates/bl_ast/Cargo.toml
+++ b/crates/bl_ast/Cargo.toml
@@ -8,14 +8,16 @@ edition = { workspace = true }
 bl_utils = { workspace = true }
 bl_macros = { workspace = true }
 
+bytecount = { workspace = true }
 derive_more = { workspace = true }
-line-span = { workspace = true }
-thin-vec = { workspace = true }
 index_vec = { workspace = true }
 itertools = { workspace = true }
-parking_lot = { workspace = true }
+line-span = { workspace = true }
+num-traits = { workspace = true }
 once_cell = { workspace = true }
+parking_lot = { workspace = true }
 replace_with = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+thin-vec = { workspace = true }

--- a/crates/bl_ast/src/ast.rs
+++ b/crates/bl_ast/src/ast.rs
@@ -1026,6 +1026,6 @@ define_tree! {
     #[derive(Debug, Clone, PartialEq)]
     #[node]
     pub struct Document {
-        pub children: Children!(Statement),
+        pub document: Child!(Body),
     }
 }

--- a/crates/bl_ast/src/lib.rs
+++ b/crates/bl_ast/src/lib.rs
@@ -6,7 +6,7 @@ mod source;
 
 pub use ast::*;
 pub use location::{ByteRange, SourceId, Span, SpannedSource};
-pub use source::{HasSource, TempSourceMap};
+pub use source::{HasSource, LineRanges, TempSourceMap};
 
 pub mod visitor {
     pub use super::ast::{

--- a/crates/bl_ast/src/location.rs
+++ b/crates/bl_ast/src/location.rs
@@ -12,7 +12,7 @@ use index_vec::Idx;
 use schemars::{self, JsonSchema};
 use serde::{self, Serialize};
 
-use crate::HasSource;
+use crate::{HasSource, source::LineRanges};
 
 pub static SOURCE_COUNT: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
 
@@ -177,12 +177,13 @@ impl Span {
 pub struct SpannedSource<'s> {
     pub source: &'s str,
     pub path: &'s PathBuf,
+    pub line_ranges: &'s LineRanges,
 }
 
 impl<'s> SpannedSource<'s> {
     /// Create a [SpannedSource] from a [String].
-    pub fn new(s: &'s str, path: &'s PathBuf) -> Self {
-        Self { source: s, path }
+    pub fn new(source: &'s str, path: &'s PathBuf, line_ranges: &'s LineRanges) -> Self {
+        Self { source, path, line_ranges }
     }
 
     /// Get a hunk of the source by the specified [ByteRange].

--- a/crates/bl_ast/src/source.rs
+++ b/crates/bl_ast/src/source.rs
@@ -1,6 +1,8 @@
 use std::{collections::HashMap, path::PathBuf};
 
+use bl_utils::range_map::RangeMap;
 use derive_more::Constructor;
+use line_span::LineSpanExt;
 
 use crate::SourceId;
 
@@ -64,5 +66,43 @@ impl HasSource for TempSourceMap {
 
     fn path(&self, source: SourceId) -> &str {
         self.map[&source].path.as_path().to_str().unwrap()
+    }
+}
+
+/// This struct is used a wrapper for a [RangeMap] in order to
+/// implement a nice display format, amongst other things.
+#[derive(Debug, Clone)]
+pub struct LineRanges {
+    /// The actual line map.
+    map: RangeMap<usize, ()>,
+}
+
+impl LineRanges {
+    /// Create a line range from a string slice.
+    pub fn new_from_str(contents: &str) -> Self {
+        // Pre-allocate the line ranges to a specific size by counting the number of
+        // newline characters within the module source.
+        let mut map = RangeMap::with_capacity(bytecount::count(contents.as_bytes(), b'\n'));
+
+        // Now, iterate through the source and record the position of each newline
+        // range, and push it into the map.
+        let mut count = 0;
+
+        for span in contents.line_spans() {
+            map.append(count..=span.end(), ());
+            count = span.ending();
+        }
+
+        Self { map }
+    }
+
+    /// Get the line number for a given index.
+    pub fn line_number(&self, index: usize) -> usize {
+        self.map.index_wrapping(index)
+    }
+
+    /// Get the line range for a given index.
+    pub fn line_end(&self, index: usize) -> usize {
+        self.map.key_wrapping(index).end()
     }
 }

--- a/crates/bl_ast_utils/src/pretty_print.rs
+++ b/crates/bl_ast_utils/src/pretty_print.rs
@@ -44,8 +44,8 @@ impl AstVisitor for AstTreePrinter<'_> {
         &self,
         node: ast::AstNodeRef<ast::Document>,
     ) -> Result<Self::DocumentRet, Self::Error> {
-        let walk::Document { children } = walk::walk_document(self, node)?;
-        Ok(TreeNode::branch("document", children))
+        let walk::Document { document } = walk::walk_document(self, node)?;
+        Ok(document)
     }
 
     type ArgRet = TreeNode;

--- a/crates/bl_fmt/Cargo.toml
+++ b/crates/bl_fmt/Cargo.toml
@@ -23,4 +23,5 @@ biome_html_parser = { git = "https://github.com/feds01/biome.git", branch = "htm
 biome_html_syntax = { git = "https://github.com/feds01/biome.git", branch = "html-unclosed-2", package = "biome_html_syntax" }
 biome_js_formatter = { git = "https://github.com/feds01/biome.git", branch = "html-unclosed-2", package = "biome_js_formatter" }
 biome_js_parser = { git = "https://github.com/feds01/biome.git", branch = "html-unclosed-2", package = "biome_js_parser" }
+biome_formatter = { git = "https://github.com/feds01/biome.git", branch = "html-unclosed-2", package = "biome_formatter" }
 biome_rowan = { git = "https://github.com/feds01/biome.git", branch = "html-unclosed-2", package = "biome_rowan" }

--- a/crates/bl_fmt/src/adapters.rs
+++ b/crates/bl_fmt/src/adapters.rs
@@ -5,7 +5,7 @@ use core::fmt;
 use bl_ast::SourceId;
 use derive_more::Constructor;
 
-use crate::diagnostics::FmtResult;
+use crate::{diagnostics::FmtResult, options::FormatterOptions};
 
 /// The type of language that the code is written in. These can be encountered
 /// when iterating through templates that are scanned by `brackelint`.
@@ -39,6 +39,7 @@ impl fmt::Display for LanguageType {
 #[derive(Debug, Clone, Copy)]
 pub struct TerminalState {
     pub language: LanguageType,
+    pub indent: u16,
 }
 
 #[derive(Debug, Clone, Constructor)]
@@ -47,8 +48,12 @@ pub struct FormatterContext {
     /// useful for diagnostics.
     pub source: SourceId,
 
-    /// The indent level.
-    pub indent: u16,
+    pub options: FormatterOptions,
+
+    /// We should be storing the last [`TerminalState`] that was
+    /// encountered. This is used to determine the language that
+    /// the code is written in.
+    pub state: TerminalState,
 }
 
 impl FormatterContext {
@@ -58,9 +63,30 @@ impl FormatterContext {
         self.source
     }
 
+    /// Get the current language of the parser.
+    #[inline(always)]
+    pub fn language(&self) -> LanguageType {
+        self.state.language
+    }
+
     /// Get the current indent level.
-    pub fn indent(&self) -> u16 {
-        self.indent
+    #[inline(always)]
+    pub fn indent_level(&self) -> u16 {
+        self.state.indent
+    }
+
+    pub fn indent_step(&self) -> u8 {
+        self.options.indent_size
+    }
+
+    /// Decrease the indent level by the indent step.
+    pub(crate) fn decrement_indent(&mut self) {
+        self.state.indent = self.state.indent.saturating_sub(self.indent_step() as u16);
+    }
+
+    /// Increase the indent level by the indent step.
+    pub(crate) fn increment_indent(&mut self) {
+        self.state.indent += self.indent_step() as u16;
     }
 }
 
@@ -68,8 +94,8 @@ impl FormatterContext {
 pub trait HasHTMLParsing {
     fn format(&mut self, contents: &str) -> FmtResult<String>;
 
-    /// Attempt to compute the [TerminalState] of the parser.
-    fn terminal_state(&self) -> Option<TerminalState>;
+    /// Get the [TerminalState] of the parser.
+    fn into_state(self) -> TerminalState;
 }
 
 /// A trait that represents a type that has the capability to parse CSS.

--- a/crates/bl_fmt/src/backends/biome/mod.rs
+++ b/crates/bl_fmt/src/backends/biome/mod.rs
@@ -85,6 +85,31 @@ impl HTMLBiomeFormatter {
     /// This is used to determine the last child of a node, which is useful for
     /// determining the terminal state of the parser.
     fn apply_state_from_tree(&mut self, tree: &HtmlRoot) {
+        let options = &self.options.html;
+        let html = tree.html();
+
+        // If we don't have any children, but we do have an EOF token, we can
+        // try and infer some context from the EOF token.
+        if html.iter().last().is_none()
+            && let Ok(_) = tree.eof_token()
+        {
+            self.state.indent = self.state.indent.saturating_sub(self.context.indent_step() as u16);
+            return;
+        }
+
+        let TerminalCalculationState::Some { language, indent } =
+            find_rightmost_child_and_extract_state(options, &html)
+        else {
+            return;
+        };
+
+        // If we've got an indent to apply, we need to apply it to the
+        // formatter state.
+        if let Some(indent) = indent {
+            self.state.indent = indent as u16;
+        }
+
+        self.state.language = language;
     }
 }
 
@@ -161,7 +186,12 @@ impl HasHTMLParsing for HTMLBiomeFormatter {
 
 enum TerminalCalculationState {
     None,
-    Some(TerminalState),
+    Some {
+        language: LanguageType,
+
+        /// Any indentation that was pending.
+        indent: Option<u8>,
+    },
     UseParent,
 }
 
@@ -179,7 +209,7 @@ impl Try for TerminalCalculationState {
             TerminalCalculationState::UseParent => std::ops::ControlFlow::Break(self),
 
             // Define which values represent "success" and should continue execution
-            val @ (TerminalCalculationState::None | TerminalCalculationState::Some(_)) => {
+            val @ (TerminalCalculationState::None | TerminalCalculationState::Some { .. }) => {
                 std::ops::ControlFlow::Continue(val)
             }
         }
@@ -199,26 +229,28 @@ impl<E> FromResidual<Result<Infallible, E>> for TerminalCalculationState {
     }
 }
 
-/// A utility function to get the rightmost child of a node.
-///
-/// This is used to determine the last child of a node, which is useful for
-/// determining the terminal state of the parser.
-fn terminal_state_from_rightmost_child(node: &HtmlElementList) -> Option<TerminalState> {
-    match find_rightmost_child_and_extract_state(node) {
-        TerminalCalculationState::Some(state) => Some(state),
-        _ => None,
-    }
-}
-
-fn find_rightmost_child_and_extract_state(node: &HtmlElementList) -> TerminalCalculationState {
+fn find_rightmost_child_and_extract_state(
+    options: &HtmlFormatOptions,
+    node: &HtmlElementList,
+) -> TerminalCalculationState {
     if let Some(child) = node.into_iter().last() {
-        // If the child is an HTML element, we need to check if it has any
-        // children.
-        let biome_html_syntax::AnyHtmlElement::HtmlElement(html_element) = child else {
+        let html_element = match child {
+            // If the child is an HTML element, we need to check if it has any
+            // children.
+            biome_html_syntax::AnyHtmlElement::HtmlElement(e) => e,
+
+            // biome_html_syntax::AnyHtmlElement::HtmlSelfClosingElement(e) => {
+            //     let indent = options.indent_width().value().wrapping_sub(2); // @@Temp: Hardcoded
+            //     return TerminalCalculationState::Some {
+            //         language: LanguageType::Html,
+            //         indent: Some(indent),
+            //     };
+            // }
+
             // If we get an element that is auxiliary, it means that we can
             // backtrack and in fact use the parent element which should be
             // the last "tag" child.
-            return TerminalCalculationState::UseParent;
+            _ => return TerminalCalculationState::UseParent,
         };
 
         let nodes = html_element.children();
@@ -226,7 +258,7 @@ fn find_rightmost_child_and_extract_state(node: &HtmlElementList) -> TerminalCal
         if !nodes.is_empty() {
             // Handle the case where the child is an HTML element, and it has
             // children.
-            match find_rightmost_child_and_extract_state(&nodes) {
+            match find_rightmost_child_and_extract_state(options, &nodes) {
                 TerminalCalculationState::UseParent => {}
                 state => return state,
             }
@@ -234,15 +266,14 @@ fn find_rightmost_child_and_extract_state(node: &HtmlElementList) -> TerminalCal
 
         let name_token = html_element.opening_element()?.name()?.value_token()?;
 
-        match name_token.text().trim() {
-            "style" => {
-                TerminalCalculationState::Some(TerminalState { language: LanguageType::Css })
-            }
-            "script" => {
-                TerminalCalculationState::Some(TerminalState { language: LanguageType::Js })
-            }
-            _ => TerminalCalculationState::Some(TerminalState { language: LanguageType::Html }),
-        }
+        let indent = html_element.closing_element().map(|_| options.indent_width().value());
+        let language = match name_token.text().trim() {
+            "style" => LanguageType::Css,
+            "script" => LanguageType::Js,
+            _ => LanguageType::Html,
+        };
+
+        TerminalCalculationState::Some { language, indent }
     } else {
         TerminalCalculationState::None
     }

--- a/crates/bl_fmt/src/backends/biome/mod.rs
+++ b/crates/bl_fmt/src/backends/biome/mod.rs
@@ -1,6 +1,11 @@
 //! The Biome backend, which utilises the `biome` crate to parse and format
 //! code.
 
+use std::{
+    convert::Infallible,
+    ops::{FromResidual, Try},
+};
+
 use biome_css_formatter::{self as css_formatter, context::CssFormatOptions};
 use biome_css_parser::{self as css_parser, CssParserOptions};
 use biome_diagnostics::DiagnosticExt;
@@ -225,6 +230,40 @@ enum TerminalCalculationState {
     UseParent,
 }
 
+impl Try for TerminalCalculationState {
+    type Output = TerminalCalculationState;
+    type Residual = TerminalCalculationState;
+
+    fn from_output(output: Self::Output) -> Self {
+        output
+    }
+
+    fn branch(self) -> std::ops::ControlFlow<Self::Residual, Self::Output> {
+        match self {
+            // Define which values should short-circuit when using ?
+            TerminalCalculationState::UseParent => std::ops::ControlFlow::Break(self),
+
+            // Define which values represent "success" and should continue execution
+            val @ (TerminalCalculationState::None | TerminalCalculationState::Some(_)) => {
+                std::ops::ControlFlow::Continue(val)
+            }
+        }
+    }
+}
+
+impl FromResidual for TerminalCalculationState {
+    fn from_residual(residual: <Self as Try>::Residual) -> Self {
+        residual
+    }
+}
+
+impl<E> FromResidual<Result<Infallible, E>> for TerminalCalculationState {
+    fn from_residual(_: Result<Infallible, E>) -> Self {
+        // When Result::Err is encountered with ?, return TerminalCalculationState::None
+        TerminalCalculationState::None
+    }
+}
+
 /// A utility function to get the rightmost child of a node.
 ///
 /// This is used to determine the last child of a node, which is useful for
@@ -258,10 +297,7 @@ fn find_rightmost_child_and_extract_state(node: &HtmlElementList) -> TerminalCal
             }
         }
 
-        // @@Todo: clean this up so that we can gracefully handle these
-        // unwraps.
-        let name_token =
-            html_element.opening_element().unwrap().name().unwrap().value_token().unwrap();
+        let name_token = html_element.opening_element()?.name()?.value_token()?;
 
         match name_token.text().trim() {
             "style" => {

--- a/crates/bl_fmt/src/backends/biome/mod.rs
+++ b/crates/bl_fmt/src/backends/biome/mod.rs
@@ -143,87 +143,6 @@ impl HasHTMLParsing for HTMLBiomeFormatter {
     }
 }
 
-struct CSSBiomeFormatter {
-    context: FormatterContext,
-
-    /// The options for the formatter, encapsulating backend specific options.
-    options: BiomeFormatterOptions,
-}
-
-impl HasCSSParsing for CSSBiomeFormatter {
-    /// Format the CSS contents using the Biome formatter.
-    ///
-    /// This will follow the algorithm:
-    ///
-    /// 1. Parse the CSS contents using the `biome_css_parser`.
-    ///
-    /// 2. If there are any errors, return them as a `FmtError`.
-    ///
-    /// 3. Format the parsed CSS using the `biome_css_formatter`.
-    ///
-    /// 4. Return the formatted CSS as a `String`.
-    ///
-    /// @@Todo: for (2 & 4) we may not want to do this, and simply return the
-    /// contents as verbatim. We could emit an event for debugging purposes
-    /// that parsing this content failed for some reason.
-    fn format(&self, contents: &str) -> FmtResult<String> {
-        // @@Todo: consider using `parse_css_with_cache` here, and store the cache
-        // within our caching system.
-        let parsed = css_parser::parse_css(
-            contents,
-            CssParserOptions::default().allow_wrong_line_comments().allow_metavariables(),
-        );
-        let language = LanguageType::Css;
-        let mut diagnostics = vec![];
-        let mut has_errors = false;
-
-        for diagnostic in parsed.diagnostics() {
-            has_errors |= diagnostic.is_error();
-
-            let message = format!("{}", diagnostic.message);
-            let err = diagnostic.clone().with_file_source_code("");
-
-            // Extract this span from the error.
-            diagnostics.push(FmtError::new(
-                FmtErrorKind::ExternalLanguageParseError { language, message },
-                err.location().span.map(|text_range| {
-                    bl_ast::Span::new(
-                        ByteRange::new(text_range.start().into(), text_range.end().into()),
-                        self.context.source(),
-                    )
-                }),
-            ));
-        }
-
-        // If there are any errors, return them.
-        if has_errors {
-            return Err(FmtError::compound(diagnostics));
-        }
-
-        // Now, format the CSS.
-        let options = self.options.css.clone();
-
-        match css_formatter::format_node(options, &parsed.syntax()) {
-            Ok(formatted) => {
-                // @@Temp: for now, just return the original contents.
-                Ok(formatted.print().unwrap().into_code())
-            }
-            Err(_) => {
-                Err(FmtError::new(FmtErrorKind::ExternalLanguageFormatError { language }, None))
-            }
-        }
-    }
-
-    /// Returns the terminal state of the CSS formatter.
-    ///
-    /// Since a CSS block is a terminal "node" in the context of a template i.e.
-    /// there may not be any other embedded languages within the CSS block,
-    /// we can safely assume that the terminal state is `Css`.
-    fn terminal_state(&self) -> Option<TerminalState> {
-        Some(TerminalState { language: LanguageType::Css })
-    }
-}
-
 enum TerminalCalculationState {
     None,
     Some(TerminalState),
@@ -310,6 +229,87 @@ fn find_rightmost_child_and_extract_state(node: &HtmlElementList) -> TerminalCal
         }
     } else {
         TerminalCalculationState::None
+    }
+}
+
+struct CSSBiomeFormatter {
+    context: FormatterContext,
+
+    /// The options for the formatter, encapsulating backend specific options.
+    options: BiomeFormatterOptions,
+}
+
+impl HasCSSParsing for CSSBiomeFormatter {
+    /// Format the CSS contents using the Biome formatter.
+    ///
+    /// This will follow the algorithm:
+    ///
+    /// 1. Parse the CSS contents using the `biome_css_parser`.
+    ///
+    /// 2. If there are any errors, return them as a `FmtError`.
+    ///
+    /// 3. Format the parsed CSS using the `biome_css_formatter`.
+    ///
+    /// 4. Return the formatted CSS as a `String`.
+    ///
+    /// @@Todo: for (2 & 4) we may not want to do this, and simply return the
+    /// contents as verbatim. We could emit an event for debugging purposes
+    /// that parsing this content failed for some reason.
+    fn format(&self, contents: &str) -> FmtResult<String> {
+        // @@Todo: consider using `parse_css_with_cache` here, and store the cache
+        // within our caching system.
+        let parsed = css_parser::parse_css(
+            contents,
+            CssParserOptions::default().allow_wrong_line_comments().allow_metavariables(),
+        );
+        let language = LanguageType::Css;
+        let mut diagnostics = vec![];
+        let mut has_errors = false;
+
+        for diagnostic in parsed.diagnostics() {
+            has_errors |= diagnostic.is_error();
+
+            let message = format!("{}", diagnostic.message);
+            let err = diagnostic.clone().with_file_source_code("");
+
+            // Extract this span from the error.
+            diagnostics.push(FmtError::new(
+                FmtErrorKind::ExternalLanguageParseError { language, message },
+                err.location().span.map(|text_range| {
+                    bl_ast::Span::new(
+                        ByteRange::new(text_range.start().into(), text_range.end().into()),
+                        self.context.source(),
+                    )
+                }),
+            ));
+        }
+
+        // If there are any errors, return them.
+        if has_errors {
+            return Err(FmtError::compound(diagnostics));
+        }
+
+        // Now, format the CSS.
+        let options = self.options.css.clone();
+
+        match css_formatter::format_node(options, &parsed.syntax()) {
+            Ok(formatted) => {
+                // @@Temp: for now, just return the original contents.
+                Ok(formatted.print().unwrap().into_code())
+            }
+            Err(_) => {
+                Err(FmtError::new(FmtErrorKind::ExternalLanguageFormatError { language }, None))
+            }
+        }
+    }
+
+    /// Returns the terminal state of the CSS formatter.
+    ///
+    /// Since a CSS block is a terminal "node" in the context of a template i.e.
+    /// there may not be any other embedded languages within the CSS block,
+    /// we can safely assume that the terminal state is `Css`.
+    fn terminal_state(&self) -> Option<TerminalState> {
+        Some(TerminalState { language: LanguageType::Css })
     }
 }
 

--- a/crates/bl_fmt/src/backends/biome/mod.rs
+++ b/crates/bl_fmt/src/backends/biome/mod.rs
@@ -9,9 +9,10 @@ use std::{
 use biome_css_formatter::{self as css_formatter, context::CssFormatOptions};
 use biome_css_parser::{self as css_parser, CssParserOptions};
 use biome_diagnostics::DiagnosticExt;
+use biome_formatter::IndentStyle;
 use biome_html_formatter::{HtmlFormatOptions, format_node};
 use biome_html_parser::parse_html;
-use biome_html_syntax::HtmlElementList;
+use biome_html_syntax::{HtmlElementList, HtmlRoot};
 use biome_js_formatter::{self as js_formatter, context::JsFormatOptions};
 use biome_js_parser::{self as js_parser, JsFileSource, JsParserOptions};
 use biome_rowan::AstNodeList;
@@ -53,7 +54,10 @@ impl BiomeFormatter {
     pub fn new() -> Self {
         Self {
             options: BiomeFormatterOptions {
-                html: HtmlFormatOptions::default(),
+                // @@Todo: we need to have this be shared across our formatting configuration.
+                html: HtmlFormatOptions::default()
+                    .with_indent_width(4.try_into().unwrap())
+                    .with_indent_style(IndentStyle::Space),
                 css: CssFormatOptions::default(),
                 // @@Temp: we might need to change this based on the source of the module, however
                 // for now we can assume that is in-fact a script that we are formatting, since
@@ -70,7 +74,18 @@ struct HTMLBiomeFormatter {
     /// The options for the formatter, encapsulating backend specific options.
     options: BiomeFormatterOptions,
 
-    state: Option<TerminalState>,
+    /// The state of the formatter, which is used to determine the
+    /// terminal state of the formatter.
+    state: TerminalState,
+}
+
+impl HTMLBiomeFormatter {
+    /// A utility function to get the rightmost child of a node.
+    ///
+    /// This is used to determine the last child of a node, which is useful for
+    /// determining the terminal state of the parser.
+    fn apply_state_from_tree(&mut self, tree: &HtmlRoot) {
+    }
 }
 
 impl HasHTMLParsing for HTMLBiomeFormatter {
@@ -92,7 +107,7 @@ impl HasHTMLParsing for HTMLBiomeFormatter {
     /// that parsing this content failed for some reason.
     fn format(&mut self, contents: &str) -> FmtResult<String> {
         let parsed = parse_html(contents);
-        let html = parsed.tree().html();
+        let tree = parsed.tree();
 
         // In order to compute the terminal state, we're going to check
         // the top most node of the HTML document, and remember the value
@@ -102,7 +117,7 @@ impl HasHTMLParsing for HTMLBiomeFormatter {
         //    - If `style``, then we must be in a CSS block.
         //    - If `script`, then we must be in a JS block.
         //    - Otherwise, we are in a HTML block.
-        self.state = terminal_state_from_rightmost_child(&html);
+        self.apply_state_from_tree(&tree);
 
         let language = LanguageType::Html;
         let mut errors = Vec::new();
@@ -129,8 +144,8 @@ impl HasHTMLParsing for HTMLBiomeFormatter {
 
         match format_node(options, &parsed.syntax()) {
             Ok(formatted) => {
-                let indent = self.context.indent();
-                Ok(formatted.print_with_indent(indent).unwrap().into_code())
+                let printed = formatted.print().unwrap();
+                Ok(printed.into_code())
             }
             Err(_) => {
                 Err(FmtError::new(FmtErrorKind::ExternalLanguageFormatError { language }, None))
@@ -138,8 +153,9 @@ impl HasHTMLParsing for HTMLBiomeFormatter {
         }
     }
 
-    fn terminal_state(&self) -> Option<TerminalState> {
-        Some(TerminalState { language: LanguageType::Html })
+    /// Returns the terminal state of the HTML formatter.
+    fn into_state(self) -> TerminalState {
+        self.state
     }
 }
 
@@ -309,7 +325,7 @@ impl HasCSSParsing for CSSBiomeFormatter {
     /// there may not be any other embedded languages within the CSS block,
     /// we can safely assume that the terminal state is `Css`.
     fn terminal_state(&self) -> Option<TerminalState> {
-        Some(TerminalState { language: LanguageType::Css })
+        Some(TerminalState { language: LanguageType::Css, indent: 0 })
     }
 }
 
@@ -387,7 +403,7 @@ impl HasJSParsing for JSBiomeFormatter {
     /// there may not be any other embedded languages within the JS block,
     /// we can safely assume that the terminal state is `Js`.
     fn terminal_state(&self) -> Option<TerminalState> {
-        Some(TerminalState { language: LanguageType::Js })
+        Some(TerminalState { language: LanguageType::Js, indent: 0 })
     }
 }
 
@@ -400,7 +416,11 @@ impl ExternalLanguagesEngineAdaptor for BiomeFormatter {
     type JSEngine = impl HasJSParsing;
 
     fn html_engine(&self, context: &FormatterContext) -> Self::HTMLEngine {
-        HTMLBiomeFormatter { context: context.clone(), options: self.options.clone(), state: None }
+        HTMLBiomeFormatter {
+            context: context.clone(),
+            options: self.options.clone(),
+            state: context.state,
+        }
     }
 
     fn css_engine(&self, context: &FormatterContext) -> Self::CSSEngine {

--- a/crates/bl_fmt/src/lib.rs
+++ b/crates/bl_fmt/src/lib.rs
@@ -1,6 +1,6 @@
 //! The bracketlint formatter.
 
-#![feature(impl_trait_in_assoc_type, try_trait_v2)]
+#![feature(impl_trait_in_assoc_type, try_trait_v2, let_chains)]
 
 use adapters::ExternalLanguagesEngineAdaptor;
 use bl_ast::{AstVisitorMutSelf, SourceId};

--- a/crates/bl_fmt/src/lib.rs
+++ b/crates/bl_fmt/src/lib.rs
@@ -1,6 +1,6 @@
 //! The bracketlint formatter.
 
-#![feature(impl_trait_in_assoc_type)]
+#![feature(impl_trait_in_assoc_type, try_trait_v2)]
 
 use adapters::ExternalLanguagesEngineAdaptor;
 use bl_ast::{AstVisitorMutSelf, SourceId};

--- a/crates/bl_fmt/src/lib.rs
+++ b/crates/bl_fmt/src/lib.rs
@@ -7,44 +7,35 @@ use bl_ast::{AstVisitorMutSelf, SourceId};
 use bl_reporting::Reports;
 use bl_workspace::Member;
 
+pub use crate::options::FormatterOptions;
+
 mod adapters;
 mod backends;
 mod diagnostics;
+mod options;
 mod visitor;
 
 fn configured_formatter() -> impl ExternalLanguagesEngineAdaptor {
     backends::biome::BiomeFormatter::new()
 }
 
-/// Various options for the formatter.
-#[derive(Debug, Clone, Copy)]
-pub struct FmtOptions {
-    indent_size: u16,
-}
-
-impl Default for FmtOptions {
-    fn default() -> Self {
-        Self { indent_size: 4 }
-    }
-}
-
 /// A query for formatting the document of a [`bl_workspace::Member`].
-pub struct FmtQuery<'q> {
-    pub options: FmtOptions,
+pub struct FormatQuery<'q> {
+    pub options: FormatterOptions,
     pub source: SourceId,
     pub member: &'q Member,
 }
 
 /// The result of formatting a [`bl_ast::Document`]. This returns the formatted
 /// content and the diagnostics that were generated during the formatting.
-pub struct FmtQueryResult {
+pub struct FormatQueryResult {
     pub buffer: String,
     pub diagnostics: Reports,
 }
 
 /// A query that returns the result of formatting a [`bl_ast::Document`].
-pub fn fmt_module(query: FmtQuery) -> FmtQueryResult {
-    let FmtQuery { member, source, options } = query;
+pub fn fmt_module(query: FormatQuery) -> FormatQueryResult {
+    let FormatQuery { member, source, options } = query;
 
     let spanned = member.spanned();
     let Some(ref document) = member.document else {
@@ -58,9 +49,9 @@ pub fn fmt_module(query: FmtQuery) -> FmtQueryResult {
     let mut formatter = visitor::Formatter::new(engine, options, source, spanned, buffer);
 
     match formatter.visit_document(document.ast_ref()) {
-        Ok(_) => FmtQueryResult { buffer: formatter.into_buffer(), diagnostics: Reports::new() },
+        Ok(_) => FormatQueryResult { buffer: formatter.into_buffer(), diagnostics: Reports::new() },
         Err(error) => {
-            FmtQueryResult { buffer: formatter.into_buffer(), diagnostics: Reports::from(error) }
+            FormatQueryResult { buffer: formatter.into_buffer(), diagnostics: Reports::from(error) }
         }
     }
 }

--- a/crates/bl_fmt/src/options.rs
+++ b/crates/bl_fmt/src/options.rs
@@ -1,0 +1,14 @@
+//! Options for the formatter.
+
+/// Various options for the formatter.
+#[derive(Debug, Clone, Copy)]
+pub struct FormatterOptions {
+    /// The size of the indent in spaces.
+    pub indent_size: u8,
+}
+
+impl Default for FormatterOptions {
+    fn default() -> Self {
+        Self { indent_size: 4 }
+    }
+}

--- a/crates/bl_fmt/src/visitor.rs
+++ b/crates/bl_fmt/src/visitor.rs
@@ -3,7 +3,10 @@ use bl_ast::{
 };
 
 use crate::{
-    adapters::{ExternalLanguagesEngineAdaptor, FormatterContext, HasHTMLParsing},
+    adapters::{
+        ExternalLanguagesEngineAdaptor, FormatterContext, HasHTMLParsing, LanguageType,
+        TerminalState,
+    },
     diagnostics::FmtError,
     options::FormatterOptions,
 };
@@ -19,9 +22,6 @@ pub(crate) struct Formatter<'fmt, EngineAdaptor: ExternalLanguagesEngineAdaptor>
 
     /// The buffer that is used to store the formatted document.
     buffer: String,
-
-    /// Any options that are used to format the document.
-    options: FmtOptions,
 
     /// The context of the formatter.
     ctx: FormatterContext,
@@ -59,7 +59,16 @@ impl<'fmt, Adaptor: ExternalLanguagesEngineAdaptor> Formatter<'fmt, Adaptor> {
         source: SpannedSource<'fmt>,
         buffer: String,
     ) -> Self {
-        Self { adaptor, buffer, source, options, ctx: FormatterContext { indent: 0, source: id } }
+        Self {
+            adaptor,
+            buffer,
+            source,
+            ctx: FormatterContext {
+                source: id,
+                options,
+                state: TerminalState { language: LanguageType::Html, indent: 0 },
+            },
+        }
     }
 
     /// Convert the formatter into the buffer.
@@ -70,7 +79,7 @@ impl<'fmt, Adaptor: ExternalLanguagesEngineAdaptor> Formatter<'fmt, Adaptor> {
     /// Apply an indent to the buffer.
     #[inline(always)]
     pub fn add_indent(&mut self) {
-        let size = self.ctx.indent * self.options.indent_size;
+        let size = self.ctx.indent_level();
 
         self.buffer.push_str(" ".repeat(size as usize).as_str());
     }
@@ -98,10 +107,9 @@ impl<'fmt, Adaptor: ExternalLanguagesEngineAdaptor> Formatter<'fmt, Adaptor> {
     where
         F: FnOnce(&mut Self) -> Result<(), FmtError>,
     {
-        // We increment the indent level before calling the function, and decrement it
-        self.ctx.indent += 1;
+        self.ctx.increment_indent();
         f(self)?;
-        self.ctx.indent -= 1;
+        self.ctx.decrement_indent();
 
         Ok(())
     }
@@ -227,13 +235,15 @@ impl<E: ExternalLanguagesEngineAdaptor> AstVisitorMutSelf for Formatter<'_, E> {
         node: bl_ast::AstNodeRef<bl_ast::Text>,
     ) -> Result<Self::TextRet, Self::Error> {
         let text = self.source.hunk(node.span().range);
-        let result = self.adaptor.html_engine(&self.ctx).format(text)?;
+        let mut engine = self.adaptor.html_engine(&self.ctx);
+        let result = engine.format(text)?;
 
         // @@Temp: for now, lets just push the HTML into the buffer.
         for line in result.lines() {
             self.push_line(line);
         }
 
+        self.ctx.state = engine.into_state();
         Ok(())
     }
 

--- a/crates/bl_fmt/src/visitor.rs
+++ b/crates/bl_fmt/src/visitor.rs
@@ -1,6 +1,7 @@
 use bl_ast::{
     AstVisitorMutSelf, SourceId, SpannedSource, ast_visitor_mut_self_default_impl, walk_mut_self,
 };
+use bl_reporting::inline::{InlineSnippet, note_on_span};
 
 use crate::{
     adapters::{
@@ -25,6 +26,16 @@ pub(crate) struct Formatter<'fmt, EngineAdaptor: ExternalLanguagesEngineAdaptor>
 
     /// The context of the formatter.
     ctx: FormatterContext,
+}
+
+impl<EngineAdaptor: ExternalLanguagesEngineAdaptor> Formatter<'_, EngineAdaptor> {
+    /// Report an error to the parser diagnostics.
+    ///
+    /// This function is used to report an error to the parser diagnostics.
+    #[inline(always)]
+    pub(crate) fn _note_on_span(&self, span: bl_ast::Span, note: impl Into<String>) {
+        note_on_span(InlineSnippet::new(&self.source, span), note.into());
+    }
 }
 
 pub enum TagKind {

--- a/crates/bl_fmt/src/visitor.rs
+++ b/crates/bl_fmt/src/visitor.rs
@@ -140,6 +140,7 @@ impl<E: ExternalLanguagesEngineAdaptor> AstVisitorMutSelf for Formatter<'_, E> {
     type Error = FmtError;
 
     ast_visitor_mut_self_default_impl!(
+        hiding: Text, For, If, IfClause, Comment, Inline, VarExpr, Body
     );
 
     type ForRet = ();
@@ -230,6 +231,35 @@ impl<E: ExternalLanguagesEngineAdaptor> AstVisitorMutSelf for Formatter<'_, E> {
 
         // Now visit the loop body.
         self.with_block(|formatter| formatter.visit_body(clause_body.ast_ref()))?;
+
+        Ok(())
+    }
+
+    type BodyRet = ();
+
+    fn visit_body(
+        &mut self,
+        node: bl_ast::AstNodeRef<bl_ast::Body>,
+    ) -> Result<Self::BodyRet, Self::Error> {
+        let bl_ast::Body { contents } = node.body();
+
+        // Visit the body of the document.
+        for item in contents.iter() {
+            walk_mut_self::walk_statement(self, item.ast_ref())?;
+
+            // We need to check for inline statements, whether we need to insert a newline
+            // or not, i.e. we need this to be a CST rather than an AST.
+            if let bl_ast::Statement::Inline(_) = item.ast_ref().body() {
+                let span = item.id.span().range;
+                let line_end = self.source.line_ranges.line_end(span.end());
+
+                // Check if the next line is the end of the line.
+                if span.end() + 1 == line_end {
+                    self.ctx.decrement_indent();
+                    self.push_hunk("\n");
+                }
+            }
+        }
 
         Ok(())
     }

--- a/crates/bl_fmt/src/visitor.rs
+++ b/crates/bl_fmt/src/visitor.rs
@@ -127,6 +127,11 @@ impl<'fmt, Adaptor: ExternalLanguagesEngineAdaptor> Formatter<'fmt, Adaptor> {
 
         // Add the closing tag.
         self.push_hunk(kind.right());
+
+        // @@Todo: we need to determine whether we need to add a newline
+        // or not. For now, we just add a newline.
+        self.push_hunk("\n");
+
         Ok(())
     }
 }
@@ -192,7 +197,7 @@ impl<E: ExternalLanguagesEngineAdaptor> AstVisitorMutSelf for Formatter<'_, E> {
 
         // Walk the clauses, and format each one of them.
         for clause in clauses.iter() {
-            walk_mut_self::walk_if_clause(self, clause.ast_ref())?;
+            self.visit_if_clause(clause.ast_ref())?;
         }
 
         if let Some(otherwise) = otherwise {
@@ -206,6 +211,7 @@ impl<E: ExternalLanguagesEngineAdaptor> AstVisitorMutSelf for Formatter<'_, E> {
     }
 
     type IfClauseRet = ();
+
     fn visit_if_clause(
         &mut self,
         node: bl_ast::AstNodeRef<bl_ast::IfClause>,

--- a/crates/bl_fmt/src/visitor.rs
+++ b/crates/bl_fmt/src/visitor.rs
@@ -127,18 +127,7 @@ impl<E: ExternalLanguagesEngineAdaptor> AstVisitorMutSelf for Formatter<'_, E> {
     type Error = FmtError;
 
     ast_visitor_mut_self_default_impl!(
-        hiding: Document, Text, For, If, IfClause, Comment, Inline, VarExpr
     );
-
-    type DocumentRet = ();
-
-    fn visit_document(
-        &mut self,
-        node: bl_ast::AstNodeRef<bl_ast::Document>,
-    ) -> Result<Self::DocumentRet, Self::Error> {
-        let _ = walk_mut_self::walk_document(self, node)?;
-        Ok(())
-    }
 
     type ForRet = ();
 

--- a/crates/bl_fmt/src/visitor.rs
+++ b/crates/bl_fmt/src/visitor.rs
@@ -3,9 +3,9 @@ use bl_ast::{
 };
 
 use crate::{
-    FmtOptions,
     adapters::{ExternalLanguagesEngineAdaptor, FormatterContext, HasHTMLParsing},
     diagnostics::FmtError,
+    options::FormatterOptions,
 };
 
 pub(crate) struct Formatter<'fmt, EngineAdaptor: ExternalLanguagesEngineAdaptor> {
@@ -54,7 +54,7 @@ impl TagKind {
 impl<'fmt, Adaptor: ExternalLanguagesEngineAdaptor> Formatter<'fmt, Adaptor> {
     pub fn new(
         adaptor: Adaptor,
-        options: FmtOptions,
+        options: FormatterOptions,
         id: SourceId,
         source: SpannedSource<'fmt>,
         buffer: String,

--- a/crates/bl_parse/src/lib.rs
+++ b/crates/bl_parse/src/lib.rs
@@ -1,10 +1,7 @@
 //! Contains all of the parsing logic for the `bl` project.
 #![feature(let_chains, if_let_guard)]
 
-use bl_ast::{
-    AstNode, AstVisitor, Document, LocalSpanMap, SourceId, Span, SpanMap, SpannedSource,
-    TempSourceMap,
-};
+use bl_ast::{AstNode, AstVisitor, Document, LocalSpanMap, SourceId, Span, SpanMap, TempSourceMap};
 use bl_ast_utils::{AstTreePrinter, TreeWriter, TreeWriterConfig};
 use bl_lexer::{Lexer, LexerMetadata, token::Token};
 use bl_reporting::{
@@ -88,7 +85,7 @@ pub fn parse_source(query: ParseQuery) -> ParseQueryResult {
     // let mut timings = StageMetrics::default();
     let ParseQuery { id, member, options } = query;
 
-    let spanned = SpannedSource::new(&member.contents, &member.path);
+    let spanned = member.spanned();
 
     // Lex the contents of the module or interactive block
     let LexerMetadata { tokens, mut diagnostics } = Lexer::new(spanned, id).tokenise();
@@ -127,15 +124,13 @@ pub fn parse_source(query: ParseQuery) -> ParseQueryResult {
 }
 
 pub fn emit_source_tree(member: &Member) {
-    let Member { path, document, .. } = member;
-
-    let spanned = SpannedSource::new(&member.contents, &member.path);
-    let tree =
-        AstTreePrinter::new(spanned).visit_document(document.as_ref().unwrap().ast_ref()).unwrap();
+    let document = member.document();
+    let spanned = member.spanned();
+    let tree = AstTreePrinter::new(spanned).visit_document(document.unwrap().ast_ref()).unwrap();
     let config = TreeWriterConfig::unicode();
     log::info!(
         "parsed module '{}':\n{}",
-        path.display(),
+        spanned.path.display(),
         TreeWriter::new_with_config(&tree, config)
     );
 }

--- a/crates/bl_parse/src/parser/mod.rs
+++ b/crates/bl_parse/src/parser/mod.rs
@@ -230,7 +230,7 @@ impl<'s> Parser<'s> {
     ///
     /// This function is used to report an error to the parser diagnostics.
     #[inline(always)]
-    pub fn _note_on_span(&self, span: ByteRange, note: impl Into<String>) {
+    pub(crate) fn _note_on_span(&self, span: ByteRange, note: impl Into<String>) {
         note_on_span(InlineSnippet::new(&self._source, self.make_span(span)), note.into());
     }
 
@@ -483,8 +483,9 @@ impl<'s> Parser<'s> {
             }
         }
 
-        let children = self.nodes_with_joined_span(children, start);
-        self.node_with_joined_span(ast::Document { children }, start)
+        let contents = self.nodes_with_joined_span(children, start);
+        let document = self.node_with_joined_span(ast::Body { contents }, start);
+        self.node_with_joined_span(ast::Document { document }, start)
     }
 
     fn parse_statement(&mut self) -> ParseResult<Option<AstNode<ast::Statement>>> {

--- a/crates/bl_utils/Cargo.toml
+++ b/crates/bl_utils/Cargo.toml
@@ -7,7 +7,9 @@ edition = { workspace = true }
 [dependencies]
 clap = { workspace = true }
 codespan-reporting = "0.11.1"
+itertools = { workspace = true }
 log = { workspace = true }
+num-traits = { workspace = true }
 once_cell = { workspace = true }
 path-absolutize = { workspace = true}
 schemars = { workspace = true }

--- a/crates/bl_utils/src/lib.rs
+++ b/crates/bl_utils/src/lib.rs
@@ -5,6 +5,7 @@ pub mod fs;
 pub mod highlight;
 pub mod logging;
 pub mod printing;
+pub mod range_map;
 pub mod stream;
 pub mod text;
 mod timers;

--- a/crates/bl_utils/src/range_map.rs
+++ b/crates/bl_utils/src/range_map.rs
@@ -1,0 +1,279 @@
+use std::{cmp::Ordering, fmt, ops::RangeInclusive};
+
+use itertools::Itertools;
+use num_traits::PrimInt;
+
+/// A wrapper around a [RangeInclusive] which is copyable, and hence is
+/// used by the [RangeMap] in order to store the ranges.
+#[derive(Copy, Clone, Hash, Debug, PartialEq, PartialOrd, Eq, Ord)]
+pub struct Range<Idx> {
+    start: Idx,
+    end: Idx,
+}
+
+impl Range<usize> {
+    pub fn new(start: usize, end: usize) -> Self {
+        Self { start, end }
+    }
+
+    pub fn start(&self) -> usize {
+        self.start
+    }
+
+    pub fn end(&self) -> usize {
+        self.end
+    }
+}
+
+impl<T: fmt::Display> fmt::Display for Range<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}..={}", self.start, self.end)
+    }
+}
+
+impl<Idx: PrimInt> Range<Idx> {
+    pub fn contains(&self, item: Idx) -> bool {
+        self.start <= item && item <= self.end
+    }
+}
+
+impl<T: PrimInt> PartialEq<T> for Range<T> {
+    fn eq(&self, x: &T) -> bool {
+        self.contains(*x)
+    }
+}
+
+impl<T: PrimInt> PartialOrd<T> for Range<T> {
+    fn partial_cmp(&self, x: &T) -> Option<Ordering> {
+        if self.end < *x {
+            Some(Ordering::Less)
+        } else if self.start > *x {
+            Some(Ordering::Greater)
+        } else {
+            Some(Ordering::Equal)
+        }
+    }
+}
+
+impl<I> From<RangeInclusive<I>> for Range<I> {
+    fn from(value: RangeInclusive<I>) -> Self {
+        let (start, end) = value.into_inner();
+        Range { start, end }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct RangeMap<I, V> {
+    /// The store that stores the [Range] which maps a range of keys
+    /// to a value.
+    store: Vec<(Range<I>, V)>,
+}
+
+impl<I: fmt::Display, V: fmt::Display> fmt::Display for RangeMap<I, V> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for (key, value) in self.store.iter() {
+            writeln!(f, "{key}: {value}")?;
+        }
+
+        Ok(())
+    }
+}
+
+impl<I: PrimInt + Clone + Copy, V> RangeMap<I, V> {
+    /// Create a new empty [RangeMap].
+    pub fn new() -> Self {
+        Self { store: vec![] }
+    }
+
+    /// Create a new [RangeMap] with a pre-allocated storage of a given
+    /// size.
+    pub fn with_capacity(length: usize) -> Self {
+        Self { store: Vec::with_capacity(length) }
+    }
+
+    /// Create a new [RangeMap] with specified ranges that are assumed
+    /// to be in order.
+    pub fn populated(items: Vec<(RangeInclusive<I>, V)>) -> Self {
+        let map = Self {
+            store: items
+                .into_iter()
+                .map(|(r, v)| (r.into(), v))
+                .sorted_by_key(|(range, _): &(Range<I>, _)| range.start)
+                .collect_vec(),
+        };
+
+        assert!(map.verify(), "range map contains overlapping keys, which is not valid");
+        map
+    }
+
+    /// Verify that the [RangeMap] does not contain any overlapping
+    /// ranges.
+    fn verify(&self) -> bool {
+        for pair in self.store.windows(2) {
+            let (left, right) = (pair[0].0, pair[1].0);
+
+            if left.end >= right.start {
+                return false;
+            }
+        }
+
+        true
+    }
+
+    /// Get the number of entries in the [RangeMap].
+    pub fn entry_count(&self) -> usize {
+        self.store.len()
+    }
+
+    /// Insert a new key-value pair into the [RangeMap].
+    pub fn insert(&mut self, key: RangeInclusive<I>, value: V) {
+        let overlaps = |left: &Range<I>, right: &Range<I>| {
+            if left.start >= right.start && left.end <= right.end {
+                return true;
+            }
+
+            left.contains(right.start) || left.contains(right.end)
+        };
+
+        let key: Range<_> = key.into();
+
+        for (index, (item, _)) in self.store.iter().enumerate() {
+            if overlaps(item, &key) {
+                panic!("keys are not allowed to overlap in a range map")
+            }
+
+            if key.start > item.end {
+                continue;
+            }
+
+            // we've found the right spot to insert the key
+            if key.end < item.start {
+                self.store.insert(index, (key, value));
+                return;
+            }
+        }
+
+        // If we've reached the end, then we can just push the key
+        // into the store.
+        self.store.push((key, value))
+    }
+
+    /// Append a line range to the end of the [RangeMap] assuming that
+    /// the final range does not overlap with any existing ranges.
+    pub fn append(&mut self, key: RangeInclusive<I>, value: V) {
+        let key: Range<_> = key.into();
+
+        // If the store is empty, we can just immediately push the range
+        // into the map, and exit early. Otherwise, we ensure that the
+        // range does not overlap with the last range in the map.
+        if let Some((last, _)) = self.store.last() {
+            if last.end >= key.start {
+                panic!("keys are not allowed to overlap in a range map")
+            }
+        }
+
+        self.store.push((key, value));
+    }
+
+    /// Get the position of an element within the range map.
+    pub fn index(&self, key: I) -> Option<usize> {
+        self.store.binary_search_by(|(r, _)| r.partial_cmp(&key).unwrap()).ok()
+    }
+
+    /// Get the position of an element within the range map or fall
+    /// back to the last element in the map. This is useful for performing
+    /// a `wrapping` search in the range.
+    pub fn index_wrapping(&self, key: I) -> usize {
+        match self.index(key) {
+            Some(index) => index,
+            None => self.store.len() - 1,
+        }
+    }
+
+    /// Get the key of from the given index, this returns the actual key
+    /// for the value, returning a [Range].
+    pub fn key(&self, key: I) -> Option<&Range<I>> {
+        let index = self.index(key)?;
+        self.store.get(index).map(|(range, _)| range)
+    }
+
+    /// This function is a `wrapping` search version for the [`Self::key()`]
+    /// function.
+    pub fn key_wrapping(&self, key: I) -> &Range<I> {
+        let index = self.index_wrapping(key);
+        &self.store[index].0
+    }
+
+    /// Get the value from the given key.
+    pub fn find(&self, key: I) -> Option<&V> {
+        let pos = self.index(key)?;
+
+        self.store.get(pos).map(|(_, value)| value)
+    }
+
+    /// Iterate over the key and value pairs currently in the
+    /// [RangeMap].
+    pub fn iter(&self) -> impl Iterator<Item = (&Range<I>, &V)> {
+        self.store.iter().map(|(r, v)| (r, v))
+    }
+}
+
+#[cfg(test)]
+mod test_super {
+    use super::*;
+
+    #[test]
+    fn test_range_map() {
+        let map = RangeMap::populated(vec![(0..=10, 'a'), (11..=20, 'b'), (21..=30, 'c')]);
+
+        // A
+        assert_eq!(map.find(2), Some(&'a'));
+        assert_eq!(map.find(7), Some(&'a'));
+        assert_eq!(map.find(0), Some(&'a'));
+
+        // B
+        assert_eq!(map.find(11), Some(&'b'));
+        assert_eq!(map.find(15), Some(&'b'));
+        assert_eq!(map.find(20), Some(&'b'));
+
+        // C
+        assert_eq!(map.find(21), Some(&'c'));
+        assert_eq!(map.find(25), Some(&'c'));
+        assert_eq!(map.find(30), Some(&'c'));
+
+        // Nothing
+        assert_eq!(map.find(31), None);
+        assert_eq!(map.find(1239), None);
+    }
+
+    #[test]
+    fn test_range_map_insert() {
+        let mut map = RangeMap::populated(vec![(0..=10, 'a'), (15..=20, 'c'), (21..=30, 'd')]);
+
+        // Insert a 11-14 range with 'b'
+        map.insert(11..=14, 'd');
+        assert_eq!(map.find(12), Some(&'d'));
+
+        // Insert into empty map
+        let mut map = RangeMap::new();
+        map.insert(0..=10, 'a');
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_invalid_range_map_insert() {
+        let mut map = RangeMap::populated(vec![(0..=10, 'a'), (15..=20, 'c'), (21..=30, 'd')]);
+
+        // Insert a 10-14 range with 'b'
+        //
+        // ##Note: this should panic since the map disallows overlapping ranges.
+        map.insert(10..=14, 'd');
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_invalid_range_map() {
+        // ##Note: this should panic since the provided ranges overlap.
+        RangeMap::populated(vec![(0..=10, 'a'), (10..=14, 'd'), (15..=20, 'c'), (21..=30, 'd')]);
+    }
+}

--- a/crates/bl_workspace/Cargo.toml
+++ b/crates/bl_workspace/Cargo.toml
@@ -20,3 +20,4 @@ parking_lot = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+derive_more = { workspace = true }

--- a/crates/bl_workspace/src/lib.rs
+++ b/crates/bl_workspace/src/lib.rs
@@ -9,10 +9,11 @@ pub mod settings;
 
 use std::{collections::HashMap, path::PathBuf};
 
-use bl_ast::{HasSource, SourceId};
+use bl_ast::{HasSource, LineRanges, SourceId};
 use bl_utils::stream::CompilerOutputStream;
 use index_vec::IndexVec;
 pub use member::Member;
+use member::MemberSourceMetadata;
 use settings::Settings;
 
 #[derive(Default)]
@@ -31,7 +32,13 @@ impl WorkspaceMembers {
     /// Reserve a member ready for setting its contents after it has completed
     /// the first stage, i.e. the parsing.
     pub fn reserve_member(&mut self, path: PathBuf, contents: String) -> SourceId {
-        let id = self.members.push(Member { path: path.clone(), contents, document: None });
+        // Calculate the "line_map" for the member.
+        //
+        // @@Future: we could make this a lazy-cell and just load it at time of use.
+        let line_map = LineRanges::new_from_str(&contents);
+        let metadata = MemberSourceMetadata::new(line_map);
+
+        let id = self.members.push(Member::new(path.clone(), contents, None, metadata));
         self.member_map.insert(path, id);
 
         id

--- a/crates/bl_workspace/src/member.rs
+++ b/crates/bl_workspace/src/member.rs
@@ -4,7 +4,14 @@
 
 use std::path::PathBuf;
 
-use bl_ast::{self as ast, SourceId, SpannedSource, TempSourceMap};
+use bl_ast::{self as ast, LineRanges, SourceId, SpannedSource, TempSourceMap};
+use derive_more::Constructor;
+
+/// A [Member] is a file that is part of a workspace. It contains the
+#[derive(Clone, Debug, Constructor)]
+pub struct MemberSourceMetadata {
+    line_map: LineRanges,
+}
 
 #[derive(Clone)]
 pub struct Member {
@@ -13,6 +20,9 @@ pub struct Member {
 
     /// The raw file contents of the member.
     pub contents: String,
+
+    /// Metadata about the source itself.
+    metadata: MemberSourceMetadata,
 
     /// The parsed document of the member.
     pub document: Option<ast::AstNode<ast::Document>>,
@@ -24,12 +34,14 @@ impl Member {
         path: PathBuf,
         contents: String,
         document: Option<ast::AstNode<ast::Document>>,
+        metadata: MemberSourceMetadata,
     ) -> Self {
-        Member { path, contents, document }
+        Member { path, contents, document, metadata }
     }
 
     pub fn spanned(&self) -> SpannedSource<'_> {
-        SpannedSource::new(&self.contents, &self.path)
+        SpannedSource::new(&self.contents, &self.path, &self.metadata.line_map)
+    }
     }
 
     pub fn document(&self) -> Option<&ast::AstNode<ast::Document>> {

--- a/crates/bl_workspace/src/member.rs
+++ b/crates/bl_workspace/src/member.rs
@@ -32,6 +32,10 @@ impl Member {
         SpannedSource::new(&self.contents, &self.path)
     }
 
+    pub fn document(&self) -> Option<&ast::AstNode<ast::Document>> {
+        self.document.as_ref()
+    }
+
     pub fn contents(&self) -> &str {
         &self.contents
     }


### PR DESCRIPTION
- **Add `Residual` convertors for `TerminalCalculationState`**
- **Move HTML traversal logic to be adjacent with HTML adaptor**
- **Simplify getting `SpannedSource` from a `Member`**
- **Use `Body` to represent a `Document`'s contents**
- **Introduce `RangeMap` data structure**
- **Introduce `LineRanges` data structure**
- **fmt: Rename `Fmt*` types to `Format*`**
- **fmt: Share indentation context between formatters**
- **fmt(biome): calculate correct resultant indentation from HTML context**
- **fmt: fix formatting `if` blocks**
- **fmt: treat inline expressions as verbatim under certain conditions**
- **fmt: add handy utility for displaying a note on a span**
