### PR TITLE
Implement more tag & expression formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -574,6 +574,7 @@ dependencies = [
  "biome_js_parser",
  "biome_rowan",
  "bl_ast",
+ "bl_lexer",
  "bl_macros",
  "bl_reporting",
  "bl_workspace",

--- a/crates/bl_ast/src/ast.rs
+++ b/crates/bl_ast/src/ast.rs
@@ -982,6 +982,10 @@ define_tree! {
             }
         }
 
+        pub fn is_inline(&self) -> bool {
+            matches!(self, Tag::Unprocessable(_) | Tag::Assignment(_) | Tag::Continue(_) | Tag::Break(_) | Tag::Generic(_) )
+        }
+
     }
 
 
@@ -1011,6 +1015,22 @@ define_tree! {
     impl Statement {
         pub fn text() -> Self {
             Statement::Text(Text {})
+        }
+
+        pub fn is_inline(&self) -> bool {
+            matches!(self, Statement::Inline(_))
+        }
+
+        pub fn is_tag(&self) -> bool {
+            matches!(self, Statement::Tag(_))
+        }
+
+        pub fn is_comment(&self) -> bool {
+            matches!(self, Statement::Comment(_))
+        }
+
+        pub fn is_text(&self) -> bool {
+            matches!(self, Statement::Text(_))
         }
 
         pub fn kind(&self) -> &'static str {

--- a/crates/bl_ast/src/location.rs
+++ b/crates/bl_ast/src/location.rs
@@ -173,7 +173,7 @@ impl Span {
 /// A [SpannedSource] is a wrapper around the contents of a source file that
 /// is stored in [SourceMap]. It features useful methods for extracting
 /// and reading sections of the source by using [Span] or [ByteRange]s.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct SpannedSource<'s> {
     pub source: &'s str,
     pub path: &'s PathBuf,

--- a/crates/bl_ast/src/location.rs
+++ b/crates/bl_ast/src/location.rs
@@ -202,6 +202,31 @@ impl<'s> SpannedSource<'s> {
     pub fn is_empty(&self) -> bool {
         self.source.is_empty()
     }
+
+    /// Get the line number of a particular byte position.
+    pub fn line_number(&self, byte: usize) -> usize {
+        self.line_ranges.line_number(byte)
+    }
+
+    /// Get the byte position of the given positions line number with
+    /// none-whitespace content. An example of this would be:
+    /// ```
+    /// // 1:  let x = 1;     
+    ///            ^    ^- the byte position within the line that is not a whitespace, i.e. the trimmed line range.
+    ///            |
+    ///            \ The byte position of the query
+    /// ```
+    pub fn trimmed_range(&self, line: usize) -> ByteRange {
+        let range = self.line_ranges.range_for_line(line);
+        let start = range.start();
+        let end = range.end();
+
+        let line = self.source[start..end].trim();
+        let start = line.as_ptr() as usize - self.source.as_ptr() as usize;
+        let end = start + line.len();
+
+        ByteRange::new(start, end)
+    }
 }
 
 /// This implementation is intended for debugging purposes within the

--- a/crates/bl_ast/src/location.rs
+++ b/crates/bl_ast/src/location.rs
@@ -210,7 +210,7 @@ impl<'s> SpannedSource<'s> {
 
     /// Get the byte position of the given positions line number with
     /// none-whitespace content. An example of this would be:
-    /// ```
+    /// ```ignore
     /// // 1:  let x = 1;     
     ///            ^    ^- the byte position within the line that is not a whitespace, i.e. the trimmed line range.
     ///            |

--- a/crates/bl_ast/src/source.rs
+++ b/crates/bl_ast/src/source.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, path::PathBuf};
 
-use bl_utils::range_map::RangeMap;
+use bl_utils::range_map::{Range, RangeMap};
 use derive_more::Constructor;
 use line_span::LineSpanExt;
 
@@ -104,5 +104,10 @@ impl LineRanges {
     /// Get the line range for a given index.
     pub fn line_end(&self, index: usize) -> usize {
         self.map.key_wrapping(index).end()
+    }
+
+    /// Get the range responsible for the given line number.
+    pub fn range_for_line(&self, line: usize) -> Range<usize> {
+        *self.map.key(line).unwrap()
     }
 }

--- a/crates/bl_fmt/Cargo.toml
+++ b/crates/bl_fmt/Cargo.toml
@@ -13,6 +13,7 @@ bl_ast = { workspace = true }
 bl_workspace = { workspace = true }
 bl_reporting = { workspace = true }
 bl_macros = { workspace = true }
+bl_lexer = { workspace = true }
 
 biome_console = { git = "https://github.com/feds01/biome.git", branch = "html-unclosed-2", package = "biome_console" }
 biome_css_formatter = { git = "https://github.com/feds01/biome.git", branch = "html-unclosed-2", package = "biome_css_formatter" }

--- a/crates/bl_fmt/src/adapters.rs
+++ b/crates/bl_fmt/src/adapters.rs
@@ -40,6 +40,7 @@ impl fmt::Display for LanguageType {
 pub struct TerminalState {
     pub language: LanguageType,
     pub indent: u16,
+    pub continue_inline: bool,
 }
 
 #[derive(Debug, Clone, Constructor)]
@@ -83,6 +84,11 @@ impl<'s> FormatterContext<'s> {
 
     pub fn indent_step(&self) -> u8 {
         self.options.indent_size
+    }
+
+    /// Enable "Continue Inline" mode.
+    pub fn continue_inline(&mut self) {
+        self.state.continue_inline = true;
     }
 
     /// Decrease the indent level by the indent step.

--- a/crates/bl_fmt/src/adapters.rs
+++ b/crates/bl_fmt/src/adapters.rs
@@ -2,7 +2,7 @@
 
 use core::fmt;
 
-use bl_ast::SourceId;
+use bl_ast::{SourceId, SpannedSource};
 use derive_more::Constructor;
 
 use crate::{diagnostics::FmtResult, options::FormatterOptions};
@@ -43,10 +43,12 @@ pub struct TerminalState {
 }
 
 #[derive(Debug, Clone, Constructor)]
-pub struct FormatterContext {
+pub struct FormatterContext<'s> {
+    pub id: SourceId,
+
     /// The source of the module that is being formatted. This is mostly
     /// useful for diagnostics.
-    pub source: SourceId,
+    pub source: SpannedSource<'s>,
 
     pub options: FormatterOptions,
 
@@ -56,10 +58,14 @@ pub struct FormatterContext {
     pub state: TerminalState,
 }
 
-impl FormatterContext {
+impl<'s> FormatterContext<'s> {
     /// Get the ID of the source that is being formatted.
     #[inline(always)]
-    pub fn source(&self) -> SourceId {
+    pub fn id(&self) -> SourceId {
+        self.id
+    }
+
+    pub fn source(&self) -> SpannedSource<'_> {
         self.source
     }
 
@@ -91,7 +97,7 @@ impl FormatterContext {
 }
 
 /// A trait that represents a type that has the capability to parse HTML.
-pub trait HasHTMLParsing {
+pub trait HasHTMLParsing<'ctx> {
     fn format(&mut self, contents: &str) -> FmtResult<String>;
 
     /// Get the [TerminalState] of the parser.
@@ -99,7 +105,7 @@ pub trait HasHTMLParsing {
 }
 
 /// A trait that represents a type that has the capability to parse CSS.
-pub trait HasCSSParsing {
+pub trait HasCSSParsing<'ctx> {
     fn format(&self, contents: &str) -> FmtResult<String>;
 
     /// Attempt to compute the [TerminalState] of the parser.
@@ -107,7 +113,7 @@ pub trait HasCSSParsing {
 }
 
 /// A trait that represents a type that has the capability to parse JavaScript.
-pub trait HasJSParsing {
+pub trait HasJSParsing<'ctx> {
     fn format(&self, contents: &str) -> FmtResult<String>;
 
     /// Attempt to compute the [TerminalState] of the parser.
@@ -115,14 +121,14 @@ pub trait HasJSParsing {
 }
 
 pub(crate) trait ExternalLanguagesEngineAdaptor {
-    type HTMLEngine: HasHTMLParsing;
-    type CSSEngine: HasCSSParsing;
-    type JSEngine: HasJSParsing;
+    type HTMLEngine<'ctx>: HasHTMLParsing<'ctx>;
+    type CSSEngine<'ctx>: HasCSSParsing<'ctx>;
+    type JSEngine<'ctx>: HasJSParsing<'ctx>;
 
     /// A constructor for running the HTML formatting engine.
-    fn html_engine(&self, context: &FormatterContext) -> Self::HTMLEngine;
+    fn html_engine<'ctx>(&self, context: &'ctx FormatterContext<'_>) -> Self::HTMLEngine<'ctx>;
 
-    fn css_engine(&self, context: &FormatterContext) -> Self::CSSEngine;
+    fn css_engine<'ctx>(&self, context: &'ctx FormatterContext<'_>) -> Self::CSSEngine<'ctx>;
 
-    fn js_engine(&self, context: &FormatterContext) -> Self::JSEngine;
+    fn js_engine<'ctx>(&self, context: &'ctx FormatterContext<'_>) -> Self::JSEngine<'ctx>;
 }

--- a/crates/bl_fmt/src/backends/biome/mod.rs
+++ b/crates/bl_fmt/src/backends/biome/mod.rs
@@ -68,8 +68,8 @@ impl BiomeFormatter {
     }
 }
 
-struct HTMLBiomeFormatter {
-    context: FormatterContext,
+struct HTMLBiomeFormatter<'ctx> {
+    context: &'ctx FormatterContext<'ctx>,
 
     /// The options for the formatter, encapsulating backend specific options.
     options: BiomeFormatterOptions,
@@ -79,7 +79,7 @@ struct HTMLBiomeFormatter {
     state: TerminalState,
 }
 
-impl HTMLBiomeFormatter {
+impl<'ctx> HTMLBiomeFormatter<'ctx> {
     /// A utility function to get the rightmost child of a node.
     ///
     /// This is used to determine the last child of a node, which is useful for
@@ -98,7 +98,7 @@ impl HTMLBiomeFormatter {
         }
 
         let TerminalCalculationState::Some { language, indent } =
-            find_rightmost_child_and_extract_state(options, &html)
+            find_rightmost_child_and_extract_state(options, &html, self.context.source())
         else {
             return;
         };
@@ -113,7 +113,7 @@ impl HTMLBiomeFormatter {
     }
 }
 
-impl HasHTMLParsing for HTMLBiomeFormatter {
+impl<'ctx> HasHTMLParsing<'ctx> for HTMLBiomeFormatter<'ctx> {
     /// Format the HTML contents using the Biome formatter.
     ///
     /// /// This will follow the algorithm:
@@ -158,7 +158,7 @@ impl HasHTMLParsing for HTMLBiomeFormatter {
                     err.location().span.map(|text_range| {
                         bl_ast::Span::new(
                             ByteRange::new(text_range.start().into(), text_range.end().into()),
-                            self.context.source(),
+                            self.context.id(),
                         )
                     }),
                 ));
@@ -279,14 +279,14 @@ fn find_rightmost_child_and_extract_state(
     }
 }
 
-struct CSSBiomeFormatter {
-    context: FormatterContext,
+struct CSSBiomeFormatter<'ctx> {
+    context: &'ctx FormatterContext<'ctx>,
 
     /// The options for the formatter, encapsulating backend specific options.
     options: BiomeFormatterOptions,
 }
 
-impl HasCSSParsing for CSSBiomeFormatter {
+impl<'ctx> HasCSSParsing<'ctx> for CSSBiomeFormatter<'ctx> {
     /// Format the CSS contents using the Biome formatter.
     ///
     /// This will follow the algorithm:
@@ -325,7 +325,7 @@ impl HasCSSParsing for CSSBiomeFormatter {
                 err.location().span.map(|text_range| {
                     bl_ast::Span::new(
                         ByteRange::new(text_range.start().into(), text_range.end().into()),
-                        self.context.source(),
+                        self.context.id(),
                     )
                 }),
             ));
@@ -360,14 +360,14 @@ impl HasCSSParsing for CSSBiomeFormatter {
     }
 }
 
-struct JSBiomeFormatter {
-    context: FormatterContext,
+struct JSBiomeFormatter<'ctx> {
+    context: &'ctx FormatterContext<'ctx>,
 
     /// The options for the formatter, encapsulating backend specific options.
     options: BiomeFormatterOptions,
 }
 
-impl HasJSParsing for JSBiomeFormatter {
+impl<'ctx> HasJSParsing<'ctx> for JSBiomeFormatter<'ctx> {
     /// Format the JS contents using the Biome formatter.
     ///
     /// This will follow the algorithm:
@@ -404,7 +404,7 @@ impl HasJSParsing for JSBiomeFormatter {
                 err.location().span.map(|text_range| {
                     bl_ast::Span::new(
                         ByteRange::new(text_range.start().into(), text_range.end().into()),
-                        self.context.source(),
+                        self.context.id(),
                     )
                 }),
             ));
@@ -442,23 +442,19 @@ impl HasJSParsing for JSBiomeFormatter {
 // `BiomeFormatter` by implementing the `HasHtmlParsing`, `HasCssParsing` and
 // `HasJsParsing` traits.
 impl ExternalLanguagesEngineAdaptor for BiomeFormatter {
-    type HTMLEngine = impl HasHTMLParsing;
-    type CSSEngine = impl HasCSSParsing;
-    type JSEngine = impl HasJSParsing;
+    type CSSEngine<'ctx> = impl HasCSSParsing<'ctx>;
+    type HTMLEngine<'ctx> = impl HasHTMLParsing<'ctx>;
+    type JSEngine<'ctx> = impl HasJSParsing<'ctx>;
 
-    fn html_engine(&self, context: &FormatterContext) -> Self::HTMLEngine {
-        HTMLBiomeFormatter {
-            context: context.clone(),
-            options: self.options.clone(),
-            state: context.state,
-        }
+    fn html_engine<'ctx>(&self, context: &'ctx FormatterContext<'ctx>) -> Self::HTMLEngine<'ctx> {
+        HTMLBiomeFormatter { context, options: self.options.clone(), state: context.state }
     }
 
-    fn css_engine(&self, context: &FormatterContext) -> Self::CSSEngine {
-        CSSBiomeFormatter { context: context.clone(), options: self.options.clone() }
+    fn css_engine<'ctx>(&self, context: &'ctx FormatterContext<'ctx>) -> Self::CSSEngine<'ctx> {
+        CSSBiomeFormatter { context, options: self.options.clone() }
     }
 
-    fn js_engine(&self, context: &FormatterContext) -> Self::JSEngine {
-        JSBiomeFormatter { context: context.clone(), options: self.options.clone() }
+    fn js_engine<'ctx>(&self, context: &'ctx FormatterContext<'ctx>) -> Self::JSEngine<'ctx> {
+        JSBiomeFormatter { context, options: self.options.clone() }
     }
 }

--- a/crates/bl_fmt/src/backends/biome/mod.rs
+++ b/crates/bl_fmt/src/backends/biome/mod.rs
@@ -15,8 +15,8 @@ use biome_html_parser::parse_html;
 use biome_html_syntax::{HtmlElementList, HtmlRoot};
 use biome_js_formatter::{self as js_formatter, context::JsFormatOptions};
 use biome_js_parser::{self as js_parser, JsFileSource, JsParserOptions};
-use biome_rowan::AstNodeList;
-use bl_ast::ByteRange;
+use biome_rowan::{AstNode, AstNodeList};
+use bl_ast::{ByteRange, SpannedSource};
 
 use crate::{
     adapters::{
@@ -93,6 +93,12 @@ impl<'ctx> HTMLBiomeFormatter<'ctx> {
         if html.iter().last().is_none()
             && let Ok(_) = tree.eof_token()
         {
+            let end: usize = html.range().end().into();
+            let contents_line_end = self.context.source().line_ranges.line_end(end);
+            if end != contents_line_end {
+                return;
+            }
+
             self.state.indent = self.state.indent.saturating_sub(self.context.indent_step() as u16);
             return;
         }
@@ -106,6 +112,8 @@ impl<'ctx> HTMLBiomeFormatter<'ctx> {
         // If we've got an indent to apply, we need to apply it to the
         // formatter state.
         if let Some(indent) = indent {
+            let current_indent = self.state.indent as i8;
+            let indent = current_indent.saturating_add(indent);
             self.state.indent = indent as u16;
         }
 
@@ -190,7 +198,7 @@ enum TerminalCalculationState {
         language: LanguageType,
 
         /// Any indentation that was pending.
-        indent: Option<u8>,
+        indent: Option<i8>,
     },
     UseParent,
 }
@@ -232,6 +240,7 @@ impl<E> FromResidual<Result<Infallible, E>> for TerminalCalculationState {
 fn find_rightmost_child_and_extract_state(
     options: &HtmlFormatOptions,
     node: &HtmlElementList,
+    spanned: SpannedSource<'_>,
 ) -> TerminalCalculationState {
     if let Some(child) = node.into_iter().last() {
         let html_element = match child {
@@ -258,15 +267,31 @@ fn find_rightmost_child_and_extract_state(
         if !nodes.is_empty() {
             // Handle the case where the child is an HTML element, and it has
             // children.
-            match find_rightmost_child_and_extract_state(options, &nodes) {
+            match find_rightmost_child_and_extract_state(options, &nodes, spanned) {
                 TerminalCalculationState::UseParent => {}
                 state => return state,
             }
         }
 
-        let name_token = html_element.opening_element()?.name()?.value_token()?;
+        let opening_element = html_element.opening_element()?;
+        let name_token = opening_element.name()?.value_token()?;
 
-        let indent = html_element.closing_element().map(|_| options.indent_width().value());
+        let size = options.indent_width().value() as i8;
+
+        let indent = match html_element.closing_element() {
+            Some(_) => Some(-size),
+            None => {
+                // @@CrazyHueristic: if the name is not a self-closing element, and it uses all
+                // of the space on the current line, we can assume that we should
+                // increase the indent level by 1.
+                let range = opening_element.range();
+                let end: usize = range.end().into();
+                let contents_line_end = spanned.line_ranges.line_end(end);
+
+                if end == contents_line_end { Some(size) } else { None }
+            }
+        };
+
         let language = match name_token.text().trim() {
             "style" => LanguageType::Css,
             "script" => LanguageType::Js,
@@ -356,7 +381,7 @@ impl<'ctx> HasCSSParsing<'ctx> for CSSBiomeFormatter<'ctx> {
     /// there may not be any other embedded languages within the CSS block,
     /// we can safely assume that the terminal state is `Css`.
     fn terminal_state(&self) -> Option<TerminalState> {
-        Some(TerminalState { language: LanguageType::Css, indent: 0 })
+        Some(TerminalState { language: LanguageType::Css, indent: 0, continue_inline: false })
     }
 }
 
@@ -434,7 +459,7 @@ impl<'ctx> HasJSParsing<'ctx> for JSBiomeFormatter<'ctx> {
     /// there may not be any other embedded languages within the JS block,
     /// we can safely assume that the terminal state is `Js`.
     fn terminal_state(&self) -> Option<TerminalState> {
-        Some(TerminalState { language: LanguageType::Js, indent: 0 })
+        Some(TerminalState { language: LanguageType::Js, indent: 0, continue_inline: false })
     }
 }
 

--- a/crates/bl_fmt/src/visitor.rs
+++ b/crates/bl_fmt/src/visitor.rs
@@ -177,6 +177,30 @@ impl<E: ExternalLanguagesEngineAdaptor> AstVisitorMutSelf for Formatter<'_, E> {
         hiding: Text, For, If, IfClause, Comment, Inline, Body, GenericTag, Arg, Name
     );
 
+    type BlockRet = ();
+
+    fn visit_block(
+        &mut self,
+        node: bl_ast::AstNodeRef<bl_ast::Block>,
+    ) -> Result<Self::BlockRet, Self::Error> {
+        let bl_ast::Block { label, block_body } = node.body();
+
+        self.within_tag(TagKind::Block, |this| {
+            if let Some(label) = label {
+                this.visit_name(label.ast_ref())?;
+                this.push_hunk(" ");
+            }
+
+            Ok(())
+        })?;
+        self.push_line("");
+
+        // Now visit the block body.
+        self.with_block(|formatter| formatter.visit_body(block_body.ast_ref()))?;
+
+        self.push_line("{% endblock %}");
+        Ok(())
+    }
     type ForRet = ();
 
     fn visit_for(

--- a/crates/bl_fmt/src/visitor.rs
+++ b/crates/bl_fmt/src/visitor.rs
@@ -169,13 +169,68 @@ impl<'fmt, Adaptor: ExternalLanguagesEngineAdaptor> Formatter<'fmt, Adaptor> {
 
         Ok(())
     }
+
+    // Extract the inline check into a separate function
+    fn check_inline_statement_newline(
+        &mut self,
+        statement: bl_ast::AstNodeRef<bl_ast::Statement>,
+        next_statement: Option<bl_ast::AstNodeRef<bl_ast::Statement>>,
+    ) -> Result<(), FmtError> {
+        match (statement.body(), next_statement.as_ref().map(|s| s.body())) {
+            (bl_ast::Statement::Text(_), Some(bl_ast::Statement::Inline(_))) => Ok(()),
+            (bl_ast::Statement::Text(_), Some(bl_ast::Statement::Tag(tag))) if tag.is_inline() => {
+                Ok(())
+            }
+
+            (bl_ast::Statement::Tag(tag), _) => {
+                if let bl_ast::Tag::Generic(generic) = tag {
+                    let name = self.ctx.source.hunk(generic.name.ast_ref().span().range);
+
+                    if bl_lexer::token::Keyword::try_from(name).is_ok() {
+                        self.end_line();
+                    }
+                }
+
+                Ok(())
+            }
+            (bl_ast::Statement::Inline(_), _) => {
+                let span = statement.id().span().range;
+                let line_end = self.ctx.source.line_ranges.line_end(span.end());
+
+                // Check if the next line is the end of the line.
+                if span.end() + 1 == line_end {
+                    self.ctx.decrement_indent();
+                    self.push_hunk("\n");
+                } else {
+                    // We need to continue the "inline" statement.
+                    self.ctx.continue_inline();
+                }
+
+                Ok(())
+            }
+            (bl_ast::Statement::Comment(_), _) => {
+                // If the statement is a comment, we need to check if
+                // the next line is the end of the line.
+                self.ctx.increment_indent();
+                self.push_hunk("\n");
+
+                // Additional logic can be added here that uses next_statement if needed
+
+                Ok(())
+            }
+            _ => {
+                self.end_line();
+                Ok(())
+            }
+        }
+    }
 }
 
 impl<E: ExternalLanguagesEngineAdaptor> AstVisitorMutSelf for Formatter<'_, E> {
     type Error = FmtError;
 
     ast_visitor_mut_self_default_impl!(
-        hiding: Text, For, If, IfClause, Comment, Inline, Body, GenericTag, Arg, Name
+        hiding: Text, For, If, IfClause, Comment, Inline, Body, GenericTag, Arg, Name, AccessExpr, Lit, Filter, Block, With, Assignment,
     );
 
     type BlockRet = ();
@@ -347,25 +402,18 @@ impl<E: ExternalLanguagesEngineAdaptor> AstVisitorMutSelf for Formatter<'_, E> {
         node: bl_ast::AstNodeRef<bl_ast::Body>,
     ) -> Result<Self::BodyRet, Self::Error> {
         let bl_ast::Body { contents } = node.body();
+        let statements: Vec<_> = contents.iter().collect();
 
-        // Visit the body of the document.
-        for item in contents.iter() {
+        // Visit the body of the document
+        for (i, item) in statements.iter().enumerate() {
             walk_mut_self::walk_statement(self, item.ast_ref())?;
 
-            // We need to check for inline statements, whether we need to insert a newline
-            // or not, i.e. we need this to be a CST rather than an AST.
-            if let bl_ast::Statement::Inline(_) = item.ast_ref().body() {
-                let span = item.id.span().range;
-                let line_end = self.source.line_ranges.line_end(span.end());
+            // Get optional next statement if it exists
+            let next_statement =
+                if i + 1 < statements.len() { Some(statements[i + 1].ast_ref()) } else { None };
 
-                // Check if the next line is the end of the line.
-                if span.end() + 1 == line_end {
-                    self.ctx.decrement_indent();
-                    self.push_hunk("\n");
-                }
-            }
+            self.check_inline_statement_newline(item.ast_ref(), next_statement)?;
         }
-
         Ok(())
     }
 
@@ -375,16 +423,38 @@ impl<E: ExternalLanguagesEngineAdaptor> AstVisitorMutSelf for Formatter<'_, E> {
         &mut self,
         node: bl_ast::AstNodeRef<bl_ast::Text>,
     ) -> Result<Self::TextRet, Self::Error> {
-        let text = self.source.hunk(node.span().range);
+        let is_inline = self.ctx.state.continue_inline;
+        let text = self.ctx.source.hunk(node.span().range);
         let mut engine = self.adaptor.html_engine(&self.ctx);
         let result = engine.format(text)?;
+        let new_state = engine.into_state();
 
-        // @@Temp: for now, lets just push the HTML into the buffer.
-        for line in result.lines() {
-            self.push_line(line);
+        let mut lines: Vec<_> = result.lines().collect();
+
+        // Remove empty lines at the end
+        while let Some(last) = lines.last() {
+            if last.trim().is_empty() {
+                lines.pop();
+            } else {
+                break;
+            }
         }
 
-        self.ctx.state = engine.into_state();
+        if is_inline {
+            self.push_hunk(lines.join("\n").as_str());
+        } else {
+            for (index, line) in lines.iter().enumerate() {
+                let is_last = index == lines.len() - 1;
+
+                if is_last {
+                    self.push_hunk(line);
+                } else {
+                    self.push_line(line);
+                }
+            }
+        }
+
+        self.ctx.state = new_state;
         Ok(())
     }
 

--- a/crates/bl_fmt/src/visitor.rs
+++ b/crates/bl_fmt/src/visitor.rs
@@ -132,11 +132,13 @@ impl<'fmt, Adaptor: ExternalLanguagesEngineAdaptor> Formatter<'fmt, Adaptor> {
     ) -> Result<(), FmtError> {
         self.add_indent();
         self.push_hunk(kind.left());
+        self.push_hunk(" ");
 
         // Run F without an indent level.
         f(self)?;
 
         // Add the closing tag.
+        self.push_hunk(" ");
         self.push_hunk(kind.right());
 
         // @@Todo: we need to determine whether we need to add a newline
@@ -165,7 +167,7 @@ impl<E: ExternalLanguagesEngineAdaptor> AstVisitorMutSelf for Formatter<'_, E> {
 
         // @@ Proof of concept: for now, we will just push a for loop into the buffer.
         self.within_tag(TagKind::Block, |this| {
-            this.push_hunk(" for ");
+            this.push_hunk("for ");
             this.visit_for_target(target.ast_ref())?;
             this.push_hunk(" in ");
             this.visit_expr(iterator.ast_ref())?;
@@ -182,7 +184,6 @@ impl<E: ExternalLanguagesEngineAdaptor> AstVisitorMutSelf for Formatter<'_, E> {
                 this.visit_name(reverse_modifier.ast_ref())?;
             }
 
-            this.push_hunk(" ");
             Ok(())
         })?;
 
@@ -232,12 +233,10 @@ impl<E: ExternalLanguagesEngineAdaptor> AstVisitorMutSelf for Formatter<'_, E> {
 
         self.within_tag(TagKind::Block, |this| {
             match kind {
-                bl_ast::ClauseKind::If => this.push_hunk(" if "),
-                bl_ast::ClauseKind::Elif => this.push_hunk(" elif "),
+                bl_ast::ClauseKind::If => this.push_hunk("if "),
+                bl_ast::ClauseKind::Elif => this.push_hunk("elif "),
             }
-            this.visit_expr(condition.ast_ref())?;
-            this.push_hunk(" ");
-            Ok(())
+            this.visit_expr(condition.ast_ref())
         })?;
 
         // Now visit the loop body.
@@ -307,12 +306,8 @@ impl<E: ExternalLanguagesEngineAdaptor> AstVisitorMutSelf for Formatter<'_, E> {
         // where the "anchor" points of the comment are, so we can treat the whole
         // area as verbatim.
         self.within_tag(TagKind::Comment, |this| {
-            this.push_hunk(" ");
-
             let text = this.source.hunk(node.span().range);
             this.push_hunk(text);
-
-            this.push_hunk(" ");
             Ok(())
         })
     }

--- a/crates/bl_fmt/src/visitor.rs
+++ b/crates/bl_fmt/src/visitor.rs
@@ -417,6 +417,19 @@ impl<E: ExternalLanguagesEngineAdaptor> AstVisitorMutSelf for Formatter<'_, E> {
         })
     }
 
+    type AccessExprRet = ();
+
+    fn visit_access_expr(
+        &mut self,
+        node: bl_ast::AstNodeRef<bl_ast::AccessExpr>,
+    ) -> Result<Self::AccessExprRet, Self::Error> {
+        let bl_ast::AccessExpr { subject, field } = node.body();
+
+        self.visit_expr(subject.ast_ref())?;
+        self.push_hunk(".");
+        self.visit_name(field.ast_ref())
+    }
+
     type NameRet = ();
 
     fn visit_name(

--- a/crates/bl_fmt/src/visitor.rs
+++ b/crates/bl_fmt/src/visitor.rs
@@ -399,4 +399,24 @@ impl<E: ExternalLanguagesEngineAdaptor> AstVisitorMutSelf for Formatter<'_, E> {
 
         Ok(())
     }
+
+    type LitRet = ();
+
+    fn visit_lit(
+        &mut self,
+        node: bl_ast::AstNodeRef<bl_ast::Lit>,
+    ) -> Result<Self::LitRet, Self::Error> {
+        match node.body() {
+            bl_ast::Lit::Int(_) | bl_ast::Lit::Float(_) | bl_ast::Lit::Str(_) => {
+                let lit = self.ctx.source.hunk(node.span().range);
+                self.push_hunk(lit);
+            }
+            bl_ast::Lit::Bool(bool) => match bool.value {
+                true => self.push_hunk("true"),
+                false => self.push_hunk("false"),
+            },
+        }
+
+        Ok(())
+    }
 }

--- a/crates/bl_fmt/src/visitor.rs
+++ b/crates/bl_fmt/src/visitor.rs
@@ -19,14 +19,11 @@ pub(crate) struct Formatter<'fmt, EngineAdaptor: ExternalLanguagesEngineAdaptor>
     /// around about the formatter.
     adaptor: EngineAdaptor,
 
-    /// The source that is used to format the document.
-    source: SpannedSource<'fmt>,
-
     /// The buffer that is used to store the formatted document.
     buffer: String,
 
     /// The context of the formatter.
-    ctx: FormatterContext,
+    ctx: FormatterContext<'fmt>,
 }
 
 impl<EngineAdaptor: ExternalLanguagesEngineAdaptor> Formatter<'_, EngineAdaptor> {
@@ -35,7 +32,7 @@ impl<EngineAdaptor: ExternalLanguagesEngineAdaptor> Formatter<'_, EngineAdaptor>
     /// This function is used to report an error to the parser diagnostics.
     #[inline(always)]
     pub(crate) fn _note_on_span(&self, span: bl_ast::Span, note: impl Into<String>) {
-        note_on_span(InlineSnippet::new(&self.source, span), note.into());
+        note_on_span(InlineSnippet::new(&self.ctx.source, span), note.into());
     }
 }
 
@@ -74,11 +71,15 @@ impl<'fmt, Adaptor: ExternalLanguagesEngineAdaptor> Formatter<'fmt, Adaptor> {
         Self {
             adaptor,
             buffer,
-            source,
             ctx: FormatterContext {
-                source: id,
+                id,
+                source,
                 options,
-                state: TerminalState { language: LanguageType::Html, indent: 0 },
+                state: TerminalState {
+                    language: LanguageType::Html,
+                    indent: 0,
+                    continue_inline: false,
+                },
             },
         }
     }
@@ -400,7 +401,7 @@ impl<E: ExternalLanguagesEngineAdaptor> AstVisitorMutSelf for Formatter<'_, E> {
         // where the "anchor" points of the comment are, so we can treat the whole
         // area as verbatim.
         self.within_tag(TagKind::Comment, |this| {
-            let text = this.source.hunk(node.span().range);
+            let text = this.ctx.source.hunk(node.span().range);
             this.push_hunk(text);
             Ok(())
         })?;
@@ -442,7 +443,7 @@ impl<E: ExternalLanguagesEngineAdaptor> AstVisitorMutSelf for Formatter<'_, E> {
         &mut self,
         node: bl_ast::AstNodeRef<bl_ast::Name>,
     ) -> Result<Self::NameRet, Self::Error> {
-        let name = self.source.hunk(node.span().range);
+        let name = self.ctx.source.hunk(node.span().range);
         self.push_hunk(name);
         Ok(())
     }

--- a/crates/bl_fmt/src/visitor.rs
+++ b/crates/bl_fmt/src/visitor.rs
@@ -1,5 +1,6 @@
 use bl_ast::{
-    AstVisitorMutSelf, SourceId, SpannedSource, ast_visitor_mut_self_default_impl, walk_mut_self,
+    AstNodes, AstVisitorMutSelf, SourceId, SpannedSource, ast_visitor_mut_self_default_impl,
+    walk_mut_self,
 };
 use bl_reporting::inline::{InlineSnippet, note_on_span};
 
@@ -173,7 +174,7 @@ impl<E: ExternalLanguagesEngineAdaptor> AstVisitorMutSelf for Formatter<'_, E> {
     type Error = FmtError;
 
     ast_visitor_mut_self_default_impl!(
-        hiding: Text, For, If, IfClause, Comment, Inline, VarExpr, Body
+        hiding: Text, For, If, IfClause, Comment, Inline, Body, GenericTag, Arg, Name
     );
 
     type ForRet = ();
@@ -355,6 +356,28 @@ impl<E: ExternalLanguagesEngineAdaptor> AstVisitorMutSelf for Formatter<'_, E> {
         let name = self.source.hunk(node.span().range);
         self.push_hunk(name);
         Ok(())
+    }
+
+    type GenericTagRet = ();
+
+    fn visit_generic_tag(
+        &mut self,
+        node: bl_ast::AstNodeRef<bl_ast::GenericTag>,
+    ) -> Result<Self::GenericTagRet, Self::Error> {
+        self.within_tag(TagKind::Block, |this| {
+            let bl_ast::GenericTag { name, args } = node.body();
+
+            this.visit_name(name.ast_ref())?;
+            this.push_hunk(" ");
+            this.visit_list_of_formatters_with_separator(
+                args,
+                &mut |this: &mut Self, arg: bl_ast::AstNodeRef<'_, bl_ast::Arg>| {
+                    this.visit_arg(arg)
+                },
+                " ",
+            )?;
+            Ok(())
+        })
     }
 
     type ArgRet = ();

--- a/crates/bl_fmt/src/visitor.rs
+++ b/crates/bl_fmt/src/visitor.rs
@@ -326,12 +326,12 @@ impl<E: ExternalLanguagesEngineAdaptor> AstVisitorMutSelf for Formatter<'_, E> {
         })
     }
 
-    type VarExprRet = ();
+    type NameRet = ();
 
-    fn visit_var_expr(
+    fn visit_name(
         &mut self,
-        node: bl_ast::AstNodeRef<bl_ast::VarExpr>,
-    ) -> Result<Self::VarExprRet, Self::Error> {
+        node: bl_ast::AstNodeRef<bl_ast::Name>,
+    ) -> Result<Self::NameRet, Self::Error> {
         let name = self.source.hunk(node.span().range);
         self.push_hunk(name);
         Ok(())

--- a/crates/bl_fmt/src/visitor.rs
+++ b/crates/bl_fmt/src/visitor.rs
@@ -201,6 +201,52 @@ impl<E: ExternalLanguagesEngineAdaptor> AstVisitorMutSelf for Formatter<'_, E> {
         self.push_line("{% endblock %}");
         Ok(())
     }
+
+    type WithRet = ();
+
+    fn visit_with(
+        &mut self,
+        node: bl_ast::AstNodeRef<bl_ast::With>,
+    ) -> Result<Self::WithRet, Self::Error> {
+        let bl_ast::With { assignments, block_body, .. } = node.body();
+
+        self.within_tag(TagKind::Block, |this| {
+            this.push_hunk("with ");
+
+            this.visit_list_of_formatters_with_separator(
+                assignments,
+                &mut |this: &mut Self, assignment: bl_ast::AstNodeRef<'_, bl_ast::Assignment>| {
+                    this.visit_assignment(assignment)
+                },
+                ", ",
+            )?;
+
+            Ok(())
+        })?;
+        self.end_line();
+
+        // Now visit the block body.
+        self.with_block(|formatter| formatter.visit_body(block_body.ast_ref()))?;
+
+        self.push_line("{% endwith %}");
+        Ok(())
+    }
+
+    type AssignmentRet = ();
+
+    fn visit_assignment(
+        &mut self,
+        node: bl_ast::AstNodeRef<bl_ast::Assignment>,
+    ) -> Result<Self::AssignmentRet, Self::Error> {
+        let bl_ast::Assignment { name, value } = node.body();
+
+        self.visit_name(name.ast_ref())?;
+        self.push_hunk(" as ");
+        self.visit_expr(value.ast_ref())?;
+
+        Ok(())
+    }
+
     type ForRet = ();
 
     fn visit_for(

--- a/crates/bl_fmt/src/visitor.rs
+++ b/crates/bl_fmt/src/visitor.rs
@@ -104,6 +104,11 @@ impl<'fmt, Adaptor: ExternalLanguagesEngineAdaptor> Formatter<'fmt, Adaptor> {
         self.buffer.push('\n');
     }
 
+    /// Push a newline into the buffer.
+    pub fn end_line(&mut self) {
+        self.buffer.push('\n');
+    }
+
     /// Push a hunk on the current line.
     #[inline(always)]
     pub fn push_hunk(&mut self, hunk: &str) {
@@ -131,7 +136,6 @@ impl<'fmt, Adaptor: ExternalLanguagesEngineAdaptor> Formatter<'fmt, Adaptor> {
         kind: TagKind,
         f: F,
     ) -> Result<(), FmtError> {
-        self.add_indent();
         self.push_hunk(kind.left());
         self.push_hunk(" ");
 
@@ -141,10 +145,6 @@ impl<'fmt, Adaptor: ExternalLanguagesEngineAdaptor> Formatter<'fmt, Adaptor> {
         // Add the closing tag.
         self.push_hunk(" ");
         self.push_hunk(kind.right());
-
-        // @@Todo: we need to determine whether we need to add a newline
-        // or not. For now, we just add a newline.
-        self.push_hunk("\n");
 
         Ok(())
     }
@@ -277,6 +277,7 @@ impl<E: ExternalLanguagesEngineAdaptor> AstVisitorMutSelf for Formatter<'_, E> {
 
             Ok(())
         })?;
+        self.end_line();
 
         // Now visit the loop body.
         self.with_block(|formatter| formatter.visit_body(loop_body.ast_ref()))?;
@@ -322,6 +323,7 @@ impl<E: ExternalLanguagesEngineAdaptor> AstVisitorMutSelf for Formatter<'_, E> {
     ) -> Result<Self::IfClauseRet, Self::Error> {
         let bl_ast::IfClause { kind, condition, clause_body } = node.body();
 
+        self.add_indent();
         self.within_tag(TagKind::Block, |this| {
             match kind {
                 bl_ast::ClauseKind::If => this.push_hunk("if "),
@@ -329,6 +331,7 @@ impl<E: ExternalLanguagesEngineAdaptor> AstVisitorMutSelf for Formatter<'_, E> {
             }
             this.visit_expr(condition.ast_ref())
         })?;
+        self.end_line();
 
         // Now visit the loop body.
         self.with_block(|formatter| formatter.visit_body(clause_body.ast_ref()))?;
@@ -400,7 +403,10 @@ impl<E: ExternalLanguagesEngineAdaptor> AstVisitorMutSelf for Formatter<'_, E> {
             let text = this.source.hunk(node.span().range);
             this.push_hunk(text);
             Ok(())
-        })
+        })?;
+        self.end_line();
+
+        Ok(())
     }
 
     type InlineRet = ();

--- a/crates/bl_fmt/src/visitor.rs
+++ b/crates/bl_fmt/src/visitor.rs
@@ -358,6 +358,26 @@ impl<E: ExternalLanguagesEngineAdaptor> AstVisitorMutSelf for Formatter<'_, E> {
         Ok(())
     }
 
+    type FilterRet = ();
+
+    fn visit_filter(
+        &mut self,
+        node: bl_ast::AstNodeRef<bl_ast::Filter>,
+    ) -> Result<Self::FilterRet, Self::Error> {
+        let bl_ast::Filter { name, args } = node.body();
+
+        self.push_hunk("|");
+        self.visit_name(name.ast_ref())?;
+        self.push_hunk(":");
+        self.visit_list_of_formatters_with_separator(
+            args,
+            &mut |this: &mut Self, arg: bl_ast::AstNodeRef<'_, bl_ast::Arg>| this.visit_arg(arg),
+            " ",
+        )?;
+
+        Ok(())
+    }
+
     type GenericTagRet = ();
 
     fn visit_generic_tag(

--- a/crates/bl_fmt/src/visitor.rs
+++ b/crates/bl_fmt/src/visitor.rs
@@ -147,6 +147,26 @@ impl<'fmt, Adaptor: ExternalLanguagesEngineAdaptor> Formatter<'fmt, Adaptor> {
 
         Ok(())
     }
+
+    fn visit_list_of_formatters_with_separator<T, F>(
+        &mut self,
+        list: &'_ AstNodes<T>,
+        fmt: &mut F,
+        separator: &str,
+    ) -> Result<(), FmtError>
+    where
+        F: FnMut(&mut Self, bl_ast::AstNodeRef<T>) -> Result<(), FmtError>,
+    {
+        list.iter().map(|item| item.ast_ref()).try_fold(false, |need_separator, item| {
+            if need_separator {
+                self.push_hunk(separator);
+            }
+            fmt(self, item)?;
+            Ok(true)
+        })?;
+
+        Ok(())
+    }
 }
 
 impl<E: ExternalLanguagesEngineAdaptor> AstVisitorMutSelf for Formatter<'_, E> {
@@ -334,6 +354,26 @@ impl<E: ExternalLanguagesEngineAdaptor> AstVisitorMutSelf for Formatter<'_, E> {
     ) -> Result<Self::NameRet, Self::Error> {
         let name = self.source.hunk(node.span().range);
         self.push_hunk(name);
+        Ok(())
+    }
+
+    type ArgRet = ();
+
+    fn visit_arg(
+        &mut self,
+        node: bl_ast::AstNodeRef<bl_ast::Arg>,
+    ) -> Result<Self::ArgRet, Self::Error> {
+        let bl_ast::Arg { name, value } = node.body();
+
+        if let Some(name) = name {
+            self.visit_name(name.ast_ref())?;
+            self.push_hunk("=");
+        }
+
+        if let Some(value) = value {
+            self.visit_expr(value.ast_ref())?;
+        }
+
         Ok(())
     }
 }

--- a/crates/bl_lexer/src/diagnostics/mod.rs
+++ b/crates/bl_lexer/src/diagnostics/mod.rs
@@ -15,7 +15,7 @@ pub enum LexerErrorKind {
     MissingExponentDigits,
 
     /// When a float literal specifies an invalid exponent. i.e.
-    /// ```
+    /// ```ignore
     /// 1.0e-1.0
     /// ```
     InvalidFloatExponent,

--- a/crates/bl_lexer/src/token/cursor.rs
+++ b/crates/bl_lexer/src/token/cursor.rs
@@ -26,7 +26,7 @@
 //! Nested trees are handled in the same way, here is an example which
 //! is annotated with token counts beginning from each token tree within
 //! the stream:
-//! ```
+//! ```ignore
 //! if x { if y { 2 } print( "bing") }
 //!      1  2 3 4 5   6    7 8  // `{`
 //!               1             // `{`
@@ -205,7 +205,7 @@ impl<'t> TokenCursor<'t> {
     /// > Use this function with caution as it doesn't perform any checks
     /// > on the tree ranges.
     ///
-    /// ```
+    /// ```ignore
     /// # use bl_lexer::token::{Token, TokenKind};
     ///
     /// let token = self.peek(1).unwrap_or_else(SomeErr(..))?;

--- a/crates/bl_parse/src/diagnostics/error.rs
+++ b/crates/bl_parse/src/diagnostics/error.rs
@@ -44,7 +44,7 @@ pub enum ParseErrorKind {
 
     /// For tags that expect a termination, e.g. `{% endif %}`, this error
     /// represents the case where the termination is missing, e.g.
-    /// ```
+    /// ```ignore
     /// {% if user.is_active %}
     ///   ...
     ///

--- a/crates/bl_parse/src/parser/mod.rs
+++ b/crates/bl_parse/src/parser/mod.rs
@@ -161,7 +161,7 @@ pub struct Parser<'s> {
 
     /// The current frame of the parser. A frame represents a particular
     /// token stream, like the file, or a subtree within the source, i.e.
-    /// ```
+    /// ```ignore
     /// {% some_tag ... %}
     /// ```
     ///
@@ -988,7 +988,7 @@ impl<'s> Parser<'s> {
 
     /// Parse the destructuring target of a for loop, i.e. the assigned variable
     /// or variables per iteration, e.g.
-    /// ```
+    /// ```ignore
     /// {% for x in y %}
     ///     ...
     /// {% endfor %}

--- a/crates/bl_reporting/src/inline.rs
+++ b/crates/bl_reporting/src/inline.rs
@@ -61,7 +61,7 @@ pub fn guarded_note_on_span<S: HasSource>(
 /// standard output, this does not panic, it is intended as a debugging utility
 /// for use when debugging the compiler.
 ///
-/// ```rust
+/// ```ignore
 /// // Don't print on `prelude` module.
 /// note_on_span(item.span(), "compiling `item`");
 ///

--- a/crates/bl_utils/src/highlight.rs
+++ b/crates/bl_utils/src/highlight.rs
@@ -6,7 +6,7 @@
 //! specific colour and text effect, and then report it using the [Reporter]
 //! struct, e.g.:
 //!
-//! ```rust
+//! ```ignore
 //! use bl_reporting::{ReportBuilder, Reports};
 //! use bl_utils::highlight::{Colour, Modifier, highlight};
 //!

--- a/crates/bl_workspace/src/lib.rs
+++ b/crates/bl_workspace/src/lib.rs
@@ -16,7 +16,7 @@ pub use member::Member;
 use member::MemberSourceMetadata;
 use settings::Settings;
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct WorkspaceMembers {
     member_map: HashMap<PathBuf, SourceId>,
 

--- a/crates/bl_workspace/src/member.rs
+++ b/crates/bl_workspace/src/member.rs
@@ -13,7 +13,7 @@ pub struct MemberSourceMetadata {
     line_map: LineRanges,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Member {
     /// The fully canonicalised path of the member.
     pub path: PathBuf,


### PR DESCRIPTION
- **Automatically space tag statement contents**
- **fmt: Format `Name` directly instead of `VarExpr`**
- **fmt: Implement argument formatting**
- **fmt: Implement generic tag formatting**
- **Add `Debug` implementations for workspace member types**
- **fmt: Implement pretty-printing for literals**
- **fmt: Implement pretty-printing for filter expressions**
- **fmt: Implement pretty-printing for block tags**
- **fmt: Implement pretty-printing for assignments & with blocks**
- **fmt: Implement pretty-printing for access expressions**
- **fmt: don't assume tag always prints on newline**
- **fmt: Pass `SpannedSource` through `FormatterContext`**
- **ast: introduce some useful utilities for getting trimmed spans via `SpannedSource`**
- **fmt: Correctly handle HTML fragments state handling**
- **fmt: correctly transport correct levels of indentation in `Body`s**
