### PR TITLE
Upgrade project dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,18 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.24.2"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
  "gimli",
 ]
 
 [[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aho-corasick"
@@ -28,19 +28,19 @@ dependencies = [
 
 [[package]]
 name = "annotate-snippets"
-version = "0.11.5"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "710e8eae58854cdc1790fcb56cca04d712a17be849eeb81da2a724bf4bae2bc4"
+checksum = "a8ee2f071d418442e50c643c4e7a4051ce3abd9dba11713cc6cdf4f4a3f3cca5"
 dependencies = [
  "anstyle",
- "unicode-width 0.2.0",
+ "unicode-width 0.2.1",
 ]
 
 [[package]]
 name = "anstream"
-version = "0.6.18"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -53,44 +53,44 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
- "once_cell",
- "windows-sys",
+ "once_cell_polyfill",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "argfile"
@@ -104,15 +104,15 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "backtrace"
-version = "0.3.75"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -120,7 +120,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
@@ -144,7 +144,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.101",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -288,7 +288,7 @@ dependencies = [
  "cfg-if",
  "countme",
  "drop_bomb",
- "indexmap 2.9.0",
+ "indexmap",
  "rustc-hash",
  "tracing",
  "unicode-width 0.1.14",
@@ -388,7 +388,7 @@ dependencies = [
  "biome_unicode_table",
  "drop_bomb",
  "enumflags2",
- "indexmap 2.9.0",
+ "indexmap",
  "rustc-hash",
  "serde_json",
  "smallvec",
@@ -477,7 +477,7 @@ dependencies = [
  "biome_text_edit",
  "biome_text_size",
  "countme",
- "hashbrown 0.15.3",
+ "hashbrown 0.15.5",
  "rustc-hash",
  "serde",
 ]
@@ -522,9 +522,9 @@ source = "git+https://github.com/feds01/biome.git?branch=html-unclosed-2#8436c26
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
 name = "bl_ast"
@@ -614,7 +614,7 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -653,7 +653,6 @@ name = "bl_utils"
 version = "0.1.0"
 dependencies = [
  "clap",
- "codespan-reporting",
  "itertools",
  "log",
  "num-traits",
@@ -718,27 +717,27 @@ dependencies = [
 
 [[package]]
 name = "bytecount"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "camino"
-version = "1.1.9"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
+checksum = "e1de8bc0aa9e9385ceb3bf0c152e3a9b9544f6c4a912c8ae504e80c1f0368603"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "clap"
-version = "4.5.37"
+version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
+checksum = "e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -746,9 +745,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.37"
+version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
+checksum = "c2ba64afa3c0a6df7fa517765e31314e983f51dda798ffba27b988194fb65dc9"
 dependencies = [
  "anstream",
  "anstyle",
@@ -759,53 +758,45 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.32"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
-
-[[package]]
-name = "codespan-reporting"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
-dependencies = [
- "termcolor",
- "unicode-width 0.1.14",
-]
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "colored"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
+checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "lazy_static",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "convert_case"
-version = "0.4.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "countme"
@@ -849,11 +840,12 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "dashmap"
-version = "5.5.3"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
 dependencies = [
  "cfg-if",
+ "crossbeam-utils",
  "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
@@ -877,7 +869,7 @@ checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -888,9 +880,9 @@ checksum = "9bda8e21c04aca2ae33ffc2fd8c23134f3cac46db123ba97bd9d3f3b8a4a85e1"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -900,9 +892,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "enumflags2"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba2f4b465f5318854c6f8dd686ede6c0a9dc67d4b1ac241cf0eb51521a309147"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
 dependencies = [
  "enumflags2_derive",
  "serde",
@@ -910,13 +902,13 @@ dependencies = [
 
 [[package]]
 name = "enumflags2_derive"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4caf64a58d7a6d65ab00639b046ff54399a39f5f2554728895ace4b297cd79"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -927,23 +919,30 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "erased-serde"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e004d887f51fcb9fef17317a2f3525c887d8aa3f4f50fed920816a688284a5b7"
+checksum = "259d404d09818dec19332e31d94558aeb442fea04c817006456c24b5460bbd4b"
 dependencies = [
  "serde",
+ "serde_core",
  "typeid",
 ]
 
 [[package]]
 name = "errno"
-version = "0.3.11"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.1",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fs-err"
@@ -956,15 +955,15 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.31.1"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "glob"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "globset"
@@ -981,30 +980,21 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.3"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 
 [[package]]
-name = "heck"
-version = "0.3.3"
+name = "hashbrown"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 
 [[package]]
 name = "heck"
@@ -1036,23 +1026,12 @@ checksum = "44faf5bb8861a9c72e20d3fb0fdbd59233e43056e2b80475ab0aacdc2e781355"
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
- "serde",
-]
-
-[[package]]
-name = "indexmap"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.3",
+ "hashbrown 0.16.0",
 ]
 
 [[package]]
@@ -1063,9 +1042,9 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -1077,16 +1056,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
 name = "line-span"
@@ -1096,15 +1069,15 @@ checksum = "29fc123b2f6600099ca18248f69e3ee02b09c4188c0d98e9a690d90dec3e408a"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1112,9 +1085,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 dependencies = [
  "serde",
  "value-bag",
@@ -1122,15 +1095,15 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
 ]
@@ -1143,7 +1116,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1157,9 +1130,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.7"
+version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
 ]
@@ -1171,19 +1144,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
-name = "os_str_bytes"
-version = "7.1.0"
+name = "once_cell_polyfill"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c86e2db86dd008b4c88c77a9bb83d9286bf77204e255bb3fda3b2eebcae66b62"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "os_str_bytes"
+version = "7.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63eceb7b5d757011a87d08eb2123db15d87fb0c281f65d101ce30a1e96c3ad5c"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -1191,15 +1170,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1222,42 +1201,43 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.11.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
  "phf_macros",
  "phf_shared",
+ "serde",
 ]
 
 [[package]]
 name = "phf_generator"
-version = "0.11.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
+ "fastrand",
  "phf_shared",
- "rand",
 ]
 
 [[package]]
 name = "phf_macros"
-version = "0.11.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
  "phf_generator",
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "phf_shared"
-version = "0.11.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher",
 ]
@@ -1270,12 +1250,12 @@ checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.32"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.101",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1301,9 +1281,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
@@ -1318,34 +1298,39 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-
-[[package]]
 name = "redox_syscall"
-version = "0.5.12"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
-name = "regex-automata"
-version = "0.4.9"
+name = "ref-cast"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "833eb9ce86d40ef33cb1306d8accf7bc8ec2bfea4355cbdebb3df68b40925cad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1354,21 +1339,21 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "replace_with"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a8614ee435691de62bcffcf4a66d91b3594bf1428a5722e79103249a095690"
+checksum = "51743d3e274e2b18df81c4dc6caf8a5b8e15dbe799e0dca05c7617380094e884"
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc-hash"
@@ -1378,15 +1363,15 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
-version = "1.0.7"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -1406,12 +1391,13 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.22"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
 dependencies = [
  "dyn-clone",
- "indexmap 1.9.3",
+ "indexmap",
+ "ref-cast",
  "schemars_derive",
  "serde",
  "serde_json",
@@ -1419,14 +1405,14 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.22"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+checksum = "33d020396d1d138dc19f1165df7545479dcd58d93810dc5d646a16e55abefa80"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.101",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1437,22 +1423,32 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.227"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "80ece43fc6fbed4eb5392ab50c07334d3e577cbf40997ee896fe7af40bba4245"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.227"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a576275b607a2c86ea29e410193df32bc680303c82f31e275bbfcafe8b33be5"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.227"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "51e694923b8824cf0e9b382adf0f60d4e05f348f357b38833a3fa5ed7c2ede04"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1463,7 +1459,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1477,14 +1473,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1505,9 +1502,9 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
 ]
@@ -1520,14 +1517,14 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum_macros"
-version = "0.21.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d06aaeeee809dbc59eb4556183dd927df67db1540de5be8d3ec0b6636358a5ec"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
- "heck 0.3.3",
+ "heck",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1621,9 +1618,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1641,12 +1638,12 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
+checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
 dependencies = [
  "rustix",
- "windows-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1668,20 +1665,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.28"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
 ]
@@ -1700,9 +1697,9 @@ checksum = "7eec5d1121208364f6793f7d2e222bf75a915c19557537745b195b253dd64217"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "unicode-segmentation"
@@ -1718,9 +1715,9 @@ checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
 name = "utf8parse"
@@ -1785,12 +1782,18 @@ dependencies = [
 
 [[package]]
 name = "winapi-util"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.1",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 
 [[package]]
 name = "windows-sys"
@@ -1798,7 +1801,25 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.4",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -1807,14 +1828,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d42b7b7f66d2a06854650af09cfdf8713e427a439c97ad65a6375318033ac4b"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -1824,10 +1862,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1836,10 +1886,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1848,10 +1910,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1860,7 +1934,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,39 +22,39 @@ bl_reporting = { path = "crates/bl_reporting" }
 bl_utils = { path = "crates/bl_utils" }
 bl_workspace = { path = "crates/bl_workspace" }
 
-anyhow = { version = "1.0.80" }
-argfile = { version = "0.2.0" }
-bitflags = { version = "2.5.0" }
-bytecount = { version = "0.6.8" }
-clap = { version = "4.5.3", features = ["derive"] }
-colored = { version = "2.1.0" }
-convert_case ="0.4"
-crossbeam-channel = "0.5.1"
-dashmap = "5.1"
 annotate-snippets = { version = "0.12.4" }
+anyhow = { version = "1.0.100" }
+argfile = { version = "0.2.1" }
+bitflags = { version = "2.9.4" }
+bytecount = { version = "0.6.9" }
+clap = { version = "4.5.48", features = ["derive"] }
+colored = { version = "3.0.0" }
+convert_case ="0.8"
+crossbeam-channel = "0.5.15"
+dashmap = "6.1"
 derive_more = { version = "2", features = ["constructor", "deref"] }
-globset = "0.4.14"
-ignore = "0.4.22"
-index_vec = "0.1.3"
-itertools = "0.13.0"
+globset = "0.4.16"
+ignore = "0.4.23"
+index_vec = "0.1.4"
+itertools = "0.14.0"
 line-span = "0.1.5"
 log = { version = "0.4", features = ["kv_unstable", "kv_serde"] }
-num-derive = "0.4.0"
-num-traits = "0.2.16"
-once_cell = "1.19.0"
+num-derive = "0.4.2"
+num-traits = "0.2.19"
+once_cell = "1.21.3"
 parking_lot = "0.12"
 path-absolutize = "3.1.1"
-phf = { version = "0.11", features = ["macros"] }
+phf = { version = "0.13", features = ["macros"] }
 proc-macro2 = "1.0.101"
 quote = "1.0"
-replace_with = "0.1.7"
-schemars = { version = "0.8.16", features = ["indexmap1"] }
-serde = { version = "1.0.217", features = ["derive"] }
-serde_json = "1.0.117"
-similar = { version = "2.4.0", features = ["inline"] }
-strum_macros = "0.21"
-thin-vec = "0.2.13"
+replace_with = "0.1.8"
+schemars = { version = "1.0.4", features = ["indexmap2"] }
+serde = { version = "1.0.227", features = ["derive"] }
+serde_json = "1.0.145"
+similar = { version = "2.7.0", features = ["inline"] }
+strum_macros = "0.27"
 syn = { version = "2.0", features = ["extra-traits", "full"] }
+thin-vec = "0.2.14"
 wild = { version = "2" }
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ once_cell = "1.19.0"
 parking_lot = "0.12"
 path-absolutize = "3.1.1"
 phf = { version = "0.11", features = ["macros"] }
-proc-macro2 = "1.0.63"
+proc-macro2 = "1.0.101"
 quote = "1.0"
 replace_with = "0.1.7"
 schemars = { version = "0.8.16", features = ["indexmap1"] }
@@ -53,8 +53,8 @@ serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.117"
 similar = { version = "2.4.0", features = ["inline"] }
 strum_macros = "0.21"
-syn = { version = "1.0", features = ["extra-traits", "full"] }
 thin-vec = "0.2.13"
+syn = { version = "2.0", features = ["extra-traits", "full"] }
 wild = { version = "2" }
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ bl_reporting = { path = "crates/bl_reporting" }
 bl_utils = { path = "crates/bl_utils" }
 bl_workspace = { path = "crates/bl_workspace" }
 
-annotate-snippets = { version = "0.11.4" }
 anyhow = { version = "1.0.80" }
 argfile = { version = "0.2.0" }
 bitflags = { version = "2.5.0" }
@@ -32,6 +31,7 @@ colored = { version = "2.1.0" }
 convert_case ="0.4"
 crossbeam-channel = "0.5.1"
 dashmap = "5.1"
+annotate-snippets = { version = "0.12.4" }
 derive_more = { version = "2", features = ["constructor", "deref"] }
 globset = "0.4.14"
 ignore = "0.4.22"

--- a/crates/bl/src/lib.rs
+++ b/crates/bl/src/lib.rs
@@ -1,7 +1,5 @@
 //! Library definition of `bl` crate.
 
-#![feature(panic_payload_as_str)]
-
 pub mod cli;
 mod commands;
 mod crash;

--- a/crates/bl_ast/src/ast.rs
+++ b/crates/bl_ast/src/ast.rs
@@ -193,12 +193,12 @@ impl<T> AstNode<T> {
     }
 
     /// Create an [AstNodeRef] from this [AstNode].
-    pub fn ast_ref(&self) -> AstNodeRef<T> {
+    pub fn ast_ref(&self) -> AstNodeRef<'_, T> {
         AstNodeRef { body: self.body.as_ref(), id: self.id }
     }
 
     /// Create an [AstNodeRefMut] from this [AstNode].
-    pub fn ast_ref_mut(&mut self) -> AstNodeRefMut<T> {
+    pub fn ast_ref_mut(&mut self) -> AstNodeRefMut<'_, T> {
         AstNodeRefMut { body: self.body.as_mut(), id: self.id }
     }
 
@@ -305,7 +305,7 @@ impl<'t, T> AstNodeRefMut<'t, T> {
     }
 
     /// Get this node as an immutable reference
-    pub fn immutable(&self) -> AstNodeRef<T> {
+    pub fn immutable(&self) -> AstNodeRef<'_, T> {
         AstNodeRef::new(self.body, self.id)
     }
 }
@@ -333,12 +333,12 @@ pub trait OwnsAstNode<T> {
     fn node_mut(&mut self) -> &mut AstNode<T>;
 
     /// Get a [AstNodeRef<T>].
-    fn node_ref(&self) -> AstNodeRef<T> {
+    fn node_ref(&self) -> AstNodeRef<'_, T> {
         self.node().ast_ref()
     }
 
     /// Get a [AstNodeRefMut<T>].
-    fn node_ref_mut(&mut self) -> AstNodeRefMut<T> {
+    fn node_ref_mut(&mut self) -> AstNodeRefMut<'_, T> {
         self.node_mut().ast_ref_mut()
     }
 }
@@ -407,7 +407,7 @@ impl<T> AstNodes<T> {
     }
 
     /// Iterate over each child whilst wrapping it in a [AstNodeRef].
-    pub fn ast_ref_iter(&self) -> impl Iterator<Item = AstNodeRef<T>> {
+    pub fn ast_ref_iter(&self) -> impl Iterator<Item = AstNodeRef<'_, T>> {
         self.nodes.iter().map(|x| x.ast_ref())
     }
 }

--- a/crates/bl_fmt/src/lib.rs
+++ b/crates/bl_fmt/src/lib.rs
@@ -1,6 +1,6 @@
 //! The bracketlint formatter.
 
-#![feature(impl_trait_in_assoc_type, try_trait_v2, let_chains)]
+#![feature(impl_trait_in_assoc_type, try_trait_v2)]
 
 use adapters::ExternalLanguagesEngineAdaptor;
 use bl_ast::{AstVisitorMutSelf, SourceId};

--- a/crates/bl_lexer/src/lib.rs
+++ b/crates/bl_lexer/src/lib.rs
@@ -1,5 +1,4 @@
 //! BL lexer implementation for the parser.
-#![feature(cell_update)]
 
 pub mod diagnostics;
 pub mod token;

--- a/crates/bl_macros/src/define_tree/difference.rs
+++ b/crates/bl_macros/src/define_tree/difference.rs
@@ -1,6 +1,6 @@
 //! Contains a helper macro to get the difference of two identifier lists.
 
-use syn::{Ident, parse::Parse};
+use syn::{Ident, Token, parse::Parse};
 
 /// Represents the difference of two lists of symbols.
 pub(crate) struct Difference {
@@ -16,39 +16,44 @@ pub(crate) struct Difference {
 /// $callback_macro_flag:ident`
 impl Parse for Difference {
     fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
-        let result = input.parse_terminated::<_, syn::Token![;]>(|parser| {
-            let mut symbols = vec![];
-            loop {
-                match parser.parse::<Ident>() {
-                    Ok(symbol) => symbols.push(symbol),
-                    Err(_) => return Ok(symbols),
-                }
-                let _ = parser.parse::<syn::Token![,]>();
+        // Parse first section: comma-separated identifiers until semicolon
+        let mut symbols = Vec::new();
+        loop {
+            symbols.push(input.parse::<Ident>()?);
+            if input.peek(Token![;]) {
+                break;
             }
-        })?;
-
-        if result.len() != 3 {
-            return Err(syn::Error::new(
-                input.span(),
-                "Expected three lists of symbols separated by a semicolon.",
-            ));
+            input.parse::<Token![,]>()?;
         }
 
-        let symbols = result[0].clone();
-        let symbols_to_remove = result[1].clone();
-        let callback_macro = result[2].clone();
-        if callback_macro.len() != 2 {
-            return Err(syn::Error::new(
-                input.span(),
-                "Expected two symbols for the callback macro.",
-            ));
+        // Parse semicolon
+        input.parse::<Token![;]>()?;
+
+        // Parse second section: comma-separated identifiers until semicolon
+        let mut symbols_to_remove = Vec::new();
+        loop {
+            if input.peek(Token![;]) {
+                break; // Empty list case
+            }
+            symbols_to_remove.push(input.parse::<Ident>()?);
+            if input.peek(Token![;]) {
+                break;
+            }
+            input.parse::<Token![,]>()?;
         }
 
-        Ok(Self {
-            symbols: symbols.into_iter().collect(),
-            symbols_to_remove: symbols_to_remove.into_iter().collect(),
-            callback_macro: callback_macro[0].clone(),
-            callback_macro_flag: callback_macro[1].clone(),
-        })
+        // Parse semicolon
+        input.parse::<Token![;]>()?;
+
+        // Parse third section: single callback macro identifier
+        let callback_macro: Ident = input.parse()?;
+
+        // Parse semicolon
+        input.parse::<Token![;]>()?;
+
+        // Parse fourth section: single callback macro flag identifier
+        let callback_macro_flag: Ident = input.parse()?;
+
+        Ok(Self { symbols, symbols_to_remove, callback_macro, callback_macro_flag })
     }
 }

--- a/crates/bl_macros/src/define_tree/emit.rs
+++ b/crates/bl_macros/src/define_tree/emit.rs
@@ -104,7 +104,7 @@ fn emit_struct_def(struct_def: &StructNodeDef, tree_def: &TreeDef) -> TokenStrea
     let StructNodeDef { visibility, attrs, name, .. } = struct_def;
 
     // Remove the #[tree_node] attribute
-    let filtered_attrs = attrs.iter().filter(|attr| !attr.path.is_ident(NODE_DEF_ATTR_NAME));
+    let filtered_attrs = attrs.iter().filter(|attr| !attr.path().is_ident(NODE_DEF_ATTR_NAME));
 
     quote! {
         #(#filtered_attrs)*
@@ -136,7 +136,7 @@ fn emit_enum_def(enum_def: &EnumNodeDef, tree_def: &TreeDef) -> TokenStream {
     let EnumNodeDef { visibility, attrs, name, .. } = enum_def;
 
     // Remove the #[tree_node] attribute
-    let filtered_attrs = attrs.iter().filter(|attr| !attr.path.is_ident(NODE_DEF_ATTR_NAME));
+    let filtered_attrs = attrs.iter().filter(|attr| !attr.path().is_ident(NODE_DEF_ATTR_NAME));
 
     quote! {
         #(#filtered_attrs)*
@@ -191,12 +191,11 @@ fn emit_visitor(tree_def: &TreeDef, nodes_mut: bool, self_mut: bool) -> TokenStr
 
 /// If the given `ty` represents a node, return the name of the node.
 fn is_node_ty(ty: &syn::Type, tree_def: &TreeDef) -> Option<syn::Ident> {
-    if let syn::Type::Path(path) = ty {
-        if let Some(ident) = path.path.get_ident() {
-            if tree_def.nodes.contains_key(ident) {
-                return Some(ident.clone());
-            }
-        }
+    if let syn::Type::Path(path) = ty
+        && let Some(ident) = path.path.get_ident()
+        && tree_def.nodes.contains_key(ident)
+    {
+        return Some(ident.clone());
     }
     None
 }
@@ -844,9 +843,7 @@ fn emit_default_impl_macros(
             };
             (hiding: [$($node:ident),* $(,)?]) => {
                 // Here we call the difference! macro to implement all the nodes that are not given
-                //
-                // @@Cleanup: figure out how to import this from this crate directly.
-                bl_macros::difference!(#(#all_nodes),*; $($node),*; #default_impl_name, node);
+                bl_macros::difference!(#(#all_nodes),*; $($node),*; #default_impl_name; node);
             };
             #(#default_impl_macro_cases)*
             // Last case is error

--- a/crates/bl_macros/src/define_tree/parse.rs
+++ b/crates/bl_macros/src/define_tree/parse.rs
@@ -154,7 +154,7 @@ impl TryFrom<&Item> for MaybeTreeNodeDef {
     fn try_from(value: &Item) -> Result<Self, Self::Error> {
         // Something is a node if it is annotated with #[node]
         let has_tree_node =
-            |attrs: &[Attribute]| attrs.iter().any(|attr| attr.path.is_ident(NODE_DEF_ATTR_NAME));
+            |attrs: &[Attribute]| attrs.iter().any(|attr| attr.path().is_ident(NODE_DEF_ATTR_NAME));
 
         match value {
             Item::Enum(enum_item) if has_tree_node(&enum_item.attrs) => Ok(MaybeTreeNodeDef(Some(
@@ -174,13 +174,13 @@ fn parse_path_field(fields: &FieldsNamed, field_name: &str) -> Result<Path, syn:
         .named
         .iter()
         .find_map(|field| {
-            if let Some(ident) = &field.ident {
-                if ident == field_name {
-                    if let Type::Path(path) = &field.ty {
-                        return Some(Ok(path.path.clone()));
-                    }
-                    return Some(Err(syn::Error::new(field.ty.span(), "Expected a path")));
+            if let Some(ident) = &field.ident
+                && ident == field_name
+            {
+                if let Type::Path(path) = &field.ty {
+                    return Some(Ok(path.path.clone()));
                 }
+                return Some(Err(syn::Error::new(field.ty.span(), "Expected a path")));
             }
             None
         })
@@ -199,18 +199,15 @@ fn parse_ident_field(fields: &FieldsNamed, field_name: &str) -> Result<Ident, sy
         .named
         .iter()
         .find_map(|field| {
-            if let Some(ident) = &field.ident {
-                if ident == field_name {
-                    if let Type::Path(path) = &field.ty {
-                        if let Some(name) = path.path.get_ident() {
-                            return Some(Ok(name.clone()));
-                        }
-                    }
-                    return Some(Err(syn::Error::new(
-                        field.ty.span(),
-                        "Expected a type identifier",
-                    )));
+            if let Some(ident) = &field.ident
+                && ident == field_name
+            {
+                if let Type::Path(path) = &field.ty
+                    && let Some(name) = path.path.get_ident()
+                {
+                    return Some(Ok(name.clone()));
                 }
+                return Some(Err(syn::Error::new(field.ty.span(), "Expected a type identifier")));
             }
             None
         })

--- a/crates/bl_macros/src/lib.rs
+++ b/crates/bl_macros/src/lib.rs
@@ -5,7 +5,7 @@ use define_tree::{
     definitions::TreeDef, difference::Difference, emit::emit_tree, validate::validate_tree_def,
 };
 use quote::quote;
-use syn::{Ident, parse_macro_input};
+use syn::parse_macro_input;
 
 mod define_tree;
 
@@ -90,9 +90,12 @@ pub fn define_tree(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 pub fn difference(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let Difference { symbols, symbols_to_remove, callback_macro, callback_macro_flag } =
         parse_macro_input!(input as Difference);
-    let difference = symbols
+
+    let difference_items: Vec<proc_macro2::TokenStream> = symbols
         .into_iter()
         .filter(|symbol| !symbols_to_remove.contains(symbol))
-        .collect::<Vec<Ident>>();
-    quote! { #( #callback_macro!(@#callback_macro_flag #difference); )* }.into()
+        .map(|symbol| quote! { #callback_macro!(@#callback_macro_flag #symbol); })
+        .collect();
+
+    quote! { #(#difference_items)* }.into()
 }

--- a/crates/bl_parse/src/diagnostics/error.rs
+++ b/crates/bl_parse/src/diagnostics/error.rs
@@ -76,11 +76,11 @@ impl From<ParseError> for Reports {
         // `ParseErrorKind::Expected` format the error message in their own way,
         // whereas all the other error types follow a conformed order to
         // formatting expected tokens.
-        if !matches!(&err.kind, ParseErrorKind::UnExpected) {
-            if let Some(kind) = err.received {
-                let atom_msg = format!(", however received {}", kind.as_error_string());
-                base_message.push_str(&atom_msg);
-            }
+        if !matches!(&err.kind, ParseErrorKind::UnExpected)
+            && let Some(kind) = err.received
+        {
+            let atom_msg = format!(", however received {}", kind.as_error_string());
+            base_message.push_str(&atom_msg);
         }
 
         // If the generated error has suggested tokens that aren't empty.

--- a/crates/bl_parse/src/lib.rs
+++ b/crates/bl_parse/src/lib.rs
@@ -1,5 +1,5 @@
 //! Contains all of the parsing logic for the `bl` project.
-#![feature(let_chains, if_let_guard)]
+#![feature(if_let_guard)]
 
 use bl_ast::{AstNode, AstVisitor, Document, LocalSpanMap, SourceId, Span, SpanMap, TempSourceMap};
 use bl_ast_utils::{AstTreePrinter, TreeWriter, TreeWriterConfig};

--- a/crates/bl_reporting/src/lib.rs
+++ b/crates/bl_reporting/src/lib.rs
@@ -37,12 +37,12 @@ pub enum ReportKind {
     Internal,
 }
 
-impl From<ReportKind> for Level {
+impl From<ReportKind> for Level<'static> {
     fn from(kind: ReportKind) -> Self {
         match kind {
-            ReportKind::Info => Level::Info,
-            ReportKind::Warning => Level::Warning,
-            ReportKind::Error | ReportKind::Internal => Level::Error,
+            ReportKind::Info => Level::INFO,
+            ReportKind::Warning => Level::WARNING,
+            ReportKind::Error | ReportKind::Internal => Level::ERROR,
         }
     }
 }

--- a/crates/bl_reporting/src/reporter.rs
+++ b/crates/bl_reporting/src/reporter.rs
@@ -5,7 +5,7 @@
 
 use std::fmt;
 
-use annotate_snippets::{Level, Renderer, Snippet};
+use annotate_snippets::{AnnotationKind, Element, Level, Renderer, Snippet};
 use bl_ast::HasSource;
 
 use crate::{Report, ReportCodeBlock, ReportElement, Reports};
@@ -43,36 +43,41 @@ impl<S: HasSource> fmt::Display for Reporter<'_, S> {
 
         for report in self.reports.iter() {
             let level = Level::from(report.kind);
-            let mut message = level.title(&report.title);
+            let mut message = level.primary_title(&report.title);
 
             // If we have an associated code, we can add it to the message.
             if let Some(ref code) = report.error_code {
                 message = message.id(code);
             }
 
+            let mut elements: Vec<Element<'_>> = vec![];
+
             for element in &report.contents {
                 match element {
                     ReportElement::CodeBlock(ReportCodeBlock { notes }) => {
                         for (span, note) in notes {
-                            message = message.snippet(
+                            elements.push(
                                 Snippet::source(self.sources.contents(span.id))
-                                    .origin(self.sources.path(span.id))
+                                    .path(self.sources.path(span.id))
                                     .fold(true)
                                     .annotation(
-                                        level
+                                        AnnotationKind::Context
                                             .span(span.range.start()..(span.range.end() + 1))
                                             .label(note.as_str()),
-                                    ),
+                                    )
+                                    .into(),
                             );
                         }
                     }
                     ReportElement::Note(report_note) => {
-                        message = message.footer(Level::Note.title(&report_note.message));
+                        elements.push(Level::INFO.message(&report_note.message).into());
                     }
                 }
             }
 
-            writeln!(f, "{}", renderer.render(message))?;
+            let report = &[message.elements(elements)];
+
+            writeln!(f, "{}", renderer.render(report))?;
         }
 
         Ok(())

--- a/crates/bl_utils/Cargo.toml
+++ b/crates/bl_utils/Cargo.toml
@@ -6,7 +6,6 @@ edition = { workspace = true }
 
 [dependencies]
 clap = { workspace = true }
-codespan-reporting = "0.11.1"
 itertools = { workspace = true }
 log = { workspace = true }
 num-traits = { workspace = true }

--- a/crates/bl_utils/src/range_map.rs
+++ b/crates/bl_utils/src/range_map.rs
@@ -166,10 +166,10 @@ impl<I: PrimInt + Clone + Copy, V> RangeMap<I, V> {
         // If the store is empty, we can just immediately push the range
         // into the map, and exit early. Otherwise, we ensure that the
         // range does not overlap with the last range in the map.
-        if let Some((last, _)) = self.store.last() {
-            if last.end >= key.start {
-                panic!("keys are not allowed to overlap in a range map")
-            }
+        if let Some((last, _)) = self.store.last()
+            && last.end >= key.start
+        {
+            panic!("keys are not allowed to overlap in a range map")
         }
 
         self.store.push((key, value));

--- a/crates/bl_utils/src/tree_writing.rs
+++ b/crates/bl_utils/src/tree_writing.rs
@@ -10,9 +10,10 @@ use serde::{Deserialize, Serialize};
 
 /// What kind of character set to use when printing compiler
 /// messages.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, JsonSchema, Default)]
 pub enum CharacterSet {
     /// Use unicode character set, this is used by default.
+    #[default]
     Unicode,
 
     /// Use the ASCII character set.
@@ -36,12 +37,6 @@ impl fmt::Display for CharacterSet {
             Self::Unicode => write!(f, "unicode"),
             Self::Ascii => write!(f, "ascii"),
         }
-    }
-}
-
-impl Default for CharacterSet {
-    fn default() -> Self {
-        Self::Unicode
     }
 }
 
@@ -159,7 +154,7 @@ impl<'t> TreeWriter<'t, '_> {
         child_index == self.tree.children.len() - 1
     }
 
-    fn next_depth(&self, child: &'t TreeNode, child_index: usize) -> TreeWriter {
+    fn next_depth(&self, child: &'t TreeNode, child_index: usize) -> TreeWriter<'_, '_> {
         let vertical_line_or_pad = iter::once(if self.is_last(child_index) {
             self.config.pad
         } else {

--- a/crates/bl_workspace/src/resolver.rs
+++ b/crates/bl_workspace/src/resolver.rs
@@ -134,25 +134,25 @@ pub struct FilesVisitor<'s, 'config> {
 impl ignore::ParallelVisitor for FilesVisitor<'_, '_> {
     fn visit(&mut self, result: std::result::Result<DirEntry, Error>) -> WalkState {
         // Respect our own exclusion behaviour.
-        if let Ok(entry) = &result {
-            if entry.depth() > 0 {
-                let path = entry.path();
-                let resolver = self.global.resolver.read().unwrap();
-                let settings = resolver.resolve(path);
+        if let Ok(entry) = &result
+            && entry.depth() > 0
+        {
+            let path = entry.path();
+            let resolver = self.global.resolver.read().unwrap();
+            let settings = resolver.resolve(path);
 
-                if let Some(file_name) = path.file_name() {
-                    let file_path = Candidate::new(path);
-                    let file_basename = Candidate::new(file_name);
-                    if match_candidate_exclusion(
-                        &file_path,
-                        &file_basename,
-                        &settings.file_resolver.exclude,
-                    ) {
-                        return WalkState::Skip;
-                    }
-                } else {
+            if let Some(file_name) = path.file_name() {
+                let file_path = Candidate::new(path);
+                let file_basename = Candidate::new(file_name);
+                if match_candidate_exclusion(
+                    &file_path,
+                    &file_basename,
+                    &settings.file_resolver.exclude,
+                ) {
                     return WalkState::Skip;
                 }
+            } else {
+                return WalkState::Skip;
             }
         }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2025-03-15"
+channel = "nightly-2025-09-27"
 components = ["rustfmt", "clippy"]
 profile = "minimal"


### PR DESCRIPTION
- **Upgrade toolchain to `nightly-2025-09-27`**
- **Upgrade `annotate-snippets` to `0.12.4`**
- **Upgrade to `syn` 2.0**
- **Upgrade remaining dependencies**
- **Remove un-used `annotate-snippets` dependency**
