### PR TITLE
Further support for tags + inline CSS/JS formatting

### DIFF
--- a/crates/bl_fmt/src/adapters.rs
+++ b/crates/bl_fmt/src/adapters.rs
@@ -115,7 +115,7 @@ pub trait HasCSSParsing<'ctx> {
     fn format(&self, contents: &str) -> FmtResult<String>;
 
     /// Attempt to compute the [TerminalState] of the parser.
-    fn terminal_state(&self) -> Option<TerminalState>;
+    fn into_state(self) -> TerminalState;
 }
 
 /// A trait that represents a type that has the capability to parse JavaScript.
@@ -123,7 +123,7 @@ pub trait HasJSParsing<'ctx> {
     fn format(&self, contents: &str) -> FmtResult<String>;
 
     /// Attempt to compute the [TerminalState] of the parser.
-    fn terminal_state(&self) -> Option<TerminalState>;
+    fn into_state(self) -> TerminalState;
 }
 
 pub(crate) trait ExternalLanguagesEngineAdaptor {

--- a/crates/bl_fmt/src/backends/biome/mod.rs
+++ b/crates/bl_fmt/src/backends/biome/mod.rs
@@ -380,8 +380,8 @@ impl<'ctx> HasCSSParsing<'ctx> for CSSBiomeFormatter<'ctx> {
     /// Since a CSS block is a terminal "node" in the context of a template i.e.
     /// there may not be any other embedded languages within the CSS block,
     /// we can safely assume that the terminal state is `Css`.
-    fn terminal_state(&self) -> Option<TerminalState> {
-        Some(TerminalState { language: LanguageType::Css, indent: 0, continue_inline: false })
+    fn into_state(self) -> TerminalState {
+        TerminalState { language: LanguageType::Css, indent: 0, continue_inline: false }
     }
 }
 
@@ -458,8 +458,8 @@ impl<'ctx> HasJSParsing<'ctx> for JSBiomeFormatter<'ctx> {
     /// Since a JS block is a terminal "node" in the context of a template i.e.
     /// there may not be any other embedded languages within the JS block,
     /// we can safely assume that the terminal state is `Js`.
-    fn terminal_state(&self) -> Option<TerminalState> {
-        Some(TerminalState { language: LanguageType::Js, indent: 0, continue_inline: false })
+    fn into_state(self) -> TerminalState {
+        TerminalState { language: LanguageType::Js, indent: 0, continue_inline: false }
     }
 }
 

--- a/crates/bl_fmt/src/visitor.rs
+++ b/crates/bl_fmt/src/visitor.rs
@@ -230,7 +230,7 @@ impl<E: ExternalLanguagesEngineAdaptor> AstVisitorMutSelf for Formatter<'_, E> {
     type Error = FmtError;
 
     ast_visitor_mut_self_default_impl!(
-        hiding: Text, For, If, IfClause, Comment, Inline, Body, GenericTag, Arg, Name, AccessExpr, Lit, Filter, Block, With, Assignment,
+        hiding: Text, For, If, IfClause, Comment, Inline, Body, GenericTag, Arg, Name, AccessExpr, Lit, Filter, Block, With, Assignment, Extends
     );
 
     type BlockRet = ();
@@ -513,6 +513,23 @@ impl<E: ExternalLanguagesEngineAdaptor> AstVisitorMutSelf for Formatter<'_, E> {
             this.visit_expr(expr.ast_ref())?;
             Ok(())
         })
+    }
+
+    type ExtendsRet = ();
+
+    fn visit_extends(
+        &mut self,
+        node: bl_ast::AstNodeRef<bl_ast::Extends>,
+    ) -> Result<Self::ExtendsRet, Self::Error> {
+        let bl_ast::Extends { template } = node.body();
+
+        self.within_tag(TagKind::Block, |this| {
+            this.push_hunk("extends ");
+            this.visit_expr(template.ast_ref())
+        })?;
+        self.end_line();
+
+        Ok(())
     }
 
     type AccessExprRet = ();

--- a/crates/bl_fmt/src/visitor.rs
+++ b/crates/bl_fmt/src/visitor.rs
@@ -242,6 +242,7 @@ impl<E: ExternalLanguagesEngineAdaptor> AstVisitorMutSelf for Formatter<'_, E> {
         let bl_ast::Block { label, block_body } = node.body();
 
         self.within_tag(TagKind::Block, |this| {
+            this.push_hunk("block ");
             if let Some(label) = label {
                 this.visit_name(label.ast_ref())?;
                 this.push_hunk(" ");

--- a/crates/bl_fmt/src/visitor.rs
+++ b/crates/bl_fmt/src/visitor.rs
@@ -6,8 +6,8 @@ use bl_reporting::inline::{InlineSnippet, note_on_span};
 
 use crate::{
     adapters::{
-        ExternalLanguagesEngineAdaptor, FormatterContext, HasHTMLParsing, LanguageType,
-        TerminalState,
+        ExternalLanguagesEngineAdaptor, FormatterContext, HasCSSParsing, HasHTMLParsing,
+        HasJSParsing, LanguageType, TerminalState,
     },
     diagnostics::FmtError,
     options::FormatterOptions,
@@ -426,9 +426,29 @@ impl<E: ExternalLanguagesEngineAdaptor> AstVisitorMutSelf for Formatter<'_, E> {
     ) -> Result<Self::TextRet, Self::Error> {
         let is_inline = self.ctx.state.continue_inline;
         let text = self.ctx.source.hunk(node.span().range);
-        let mut engine = self.adaptor.html_engine(&self.ctx);
-        let result = engine.format(text)?;
-        let new_state = engine.into_state();
+
+        // We need to check which language engine to use for the formatting.
+        let (result, state) = match self.ctx.state.language {
+            LanguageType::Html => {
+                let mut engine = self.adaptor.html_engine(&self.ctx);
+                let result = engine.format(text)?;
+                let new_state = engine.into_state();
+                (result, new_state)
+            }
+            LanguageType::Css => {
+                let engine = self.adaptor.css_engine(&self.ctx);
+                let result = engine.format(text)?;
+                let new_state = engine.into_state();
+                (result, new_state)
+            }
+            LanguageType::Js => {
+                let engine = self.adaptor.js_engine(&self.ctx);
+                let result = engine.format(text)?;
+                let new_state = engine.into_state();
+                (result, new_state)
+            }
+            LanguageType::Text => (text.to_string(), self.ctx.state),
+        };
 
         let mut lines: Vec<_> = result.lines().collect();
 
@@ -455,7 +475,7 @@ impl<E: ExternalLanguagesEngineAdaptor> AstVisitorMutSelf for Formatter<'_, E> {
             }
         }
 
-        self.ctx.state = new_state;
+        self.ctx.state = state;
         Ok(())
     }
 


### PR DESCRIPTION
- **Standardise `Engine::into_state` method signatures**
- **Fix `block` label rendering**
- **Support rendering and formatting `CSS` and `JS` fragments**
- **Support rendering `extends` tags**
